### PR TITLE
① readline由来のリークを無視するファイルを定義

### DIFF
--- a/readline.supp
+++ b/readline.supp
@@ -1,0 +1,38 @@
+# Valgrind suppression file for readline library memory leaks
+# Usage: valgrind --leak-check=full --suppressions=readline.supp ./minishell
+
+# readline関数の一般的なメモリ確保を抑制
+# readline()はプログラム終了までメモリを保持する
+{
+   readline_leak_1
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:xmalloc
+   ...
+   fun:readline
+}
+
+# キーマップ初期化時のメモリ確保を抑制
+# rl_make_bare_keymap: キーバインド設定用の内部データ構造を作成
+# readline初期化時に1度だけ実行され、プログラム終了まで保持される
+{
+   readline_leak_2
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:xmalloc
+   fun:rl_make_bare_keymap
+   ...
+}
+
+# readlineライブラリ全体からのメモリ確保を抑制（最も包括的）
+# libreadline.so由来のあらゆるメモリ確保をカバー
+{
+   readline_leak_3
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:*alloc
+   ...
+   obj:*/libreadline.so*
+}

--- a/src/prompt/prompt.c
+++ b/src/prompt/prompt.c
@@ -31,4 +31,5 @@ void	prompt(void (*handler)(char *input))
 		if (handler)
 			handler(input);
 	}
+	rl_clear_history();
 }


### PR DESCRIPTION
## やったこと
<!--
「このPRで何を実現したか」を一言で簡潔に列挙してください。
チームでの認識合わせのため、最初に目を通す人の「PRを読むモチベーション」になります。
- ~~~画面を追加しました
- ~~~API連携の処理をした。
-->
- readline由来のメモリリークを無視するためのValgrindサプレッションファイル(`readline.supp`)を追加
- プログラム終了時に`rl_clear_history()`を呼び出してreadlineの履歴をクリーンアップ

## 懸念点 / レビューしてほしいポイント
<!--
レビューの観点を明確にしておくと、レビュワーも的確なフィードバックができます。
「この書き方でよかったか不安」「stateの持ち方に自信がない」など、些細なことでもOKです。
-->
- サプレッションファイルの内容が適切か

## なぜこの変更が必要か

### readline由来のメモリリークについて
Valgrindでメモリチェックを行うと、readline関数から`still reachable`なメモリリークが報告されます。これは以下の理由により発生します:

1. **readlineライブラリの内部実装**
   - 初回呼び出し時にキーマップ（キーバインド設定）などの内部データ構造を作成
   - プログラム終了まで保持され、ユーザーが直接解放できない

2. **`still reachable`**
   - メモリへの参照が残っていてもリークとして扱われる
   - 自分のコードで`still reachable`が出たら修正が必要
   - **ただし、readline由来のものだけは例外**（ライブラリの仕様のため対策不可）

3. **42の評価基準**
   - すべての種類のメモリリークは許容されない
   - readline由来のリークのみ、ライブラリの制約として認められる、、、はず。
   - 自分のコード由来のリーク（`still reachable`含む）は絶対に残してはいけない

### 対策
- **`readline.supp`**: Valgrindにreadline由来のリークを無視させる設定ファイル

## 動作確認
<!--
自分の変更をレビュワーが動作チェックできるように書きましょう！

-->
- [] norminetteを通過している。
- [] makeコマンドでビルドできる。
- [] valgrindでリークチェックをした。
  - サプレッションなし（readline由来のリークが表示される）:
    ```bash
    valgrind --leak-check=full --show-leak-kinds=all -s -q ./minishell
    ```
  - サプレッションあり（readline由来のリークのみを無視）:
    ```bash
    valgrind --leak-check=full --suppressions=readline.supp --show-leak-kinds=all -s -q ./minishell
    ```
- [] **自分のコード由来のリーク（all kinds）がないことを確認**
  - `definite`, `indirect`, `possible`, `still reachable`のすべてが0であること
  - readline由来以外のリークは一切許容されない

## ひとこと
<!--
シンプルな感想を書きましょう！
-->
