### PR TITLE
envpからenv_tableを作成するように (main関数も環境分け)

### DIFF
--- a/.github/workflows/leak-check.yml
+++ b/.github/workflows/leak-check.yml
@@ -32,13 +32,17 @@ jobs:
         echo "✅ minishell binary found"
         ls -la ./minishell
     
-    - name: Create test script
+    - name: Create test script for production mode
       run: |
-        cat << 'EOF' > test_input.sh
+        cat << 'EOF' > test_prod.sh
         #!/bin/bash
         
+        echo "=========================================="
+        echo "🚀 Testing PRODUCTION mode"
+        echo "=========================================="
+        
         # minishellにコマンドを送信してメモリリークをチェック
-        echo "Starting memory leak test..."
+        echo "Starting memory leak test for production mode..."
         
         # expectスタイルでインタラクティブな入力をシミュレート
         (
@@ -52,43 +56,43 @@ jobs:
                      --track-origins=yes \
                      --suppressions=./readline.supp \
                      --error-exitcode=42 \
-                     --log-file=valgrind_output.txt \
+                     --log-file=valgrind_prod.txt \
                      ./minishell 2>&1
         
         VALGRIND_EXIT=$?
         
         echo ""
         echo "=========================================="
-        echo "Valgrind Output:"
+        echo "Valgrind Output (Production):"
         echo "=========================================="
-        cat valgrind_output.txt
+        cat valgrind_prod.txt
         echo "=========================================="
         
         # Valgrindの結果を解析
         if [ $VALGRIND_EXIT -eq 42 ]; then
           echo ""
-          echo "❌ MEMORY LEAK DETECTED!"
+          echo "❌ MEMORY LEAK DETECTED in PRODUCTION mode!"
           echo ""
           echo "Summary of leaks:"
-          grep "definitely lost" valgrind_output.txt || echo "No definitely lost blocks"
-          grep "indirectly lost" valgrind_output.txt || echo "No indirectly lost blocks"
-          grep "possibly lost" valgrind_output.txt || echo "No possibly lost blocks"
+          grep "definitely lost" valgrind_prod.txt || echo "No definitely lost blocks"
+          grep "indirectly lost" valgrind_prod.txt || echo "No indirectly lost blocks"
+          grep "possibly lost" valgrind_prod.txt || echo "No possibly lost blocks"
           exit 1
         else
           echo ""
-          echo "✅ NO MEMORY LEAKS DETECTED"
+          echo "✅ NO MEMORY LEAKS DETECTED in PRODUCTION mode"
           
           # リークサマリーを表示
           echo ""
           echo "Leak Summary:"
-          grep "LEAK SUMMARY" valgrind_output.txt -A 5 || true
+          grep "LEAK SUMMARY" valgrind_prod.txt -A 5 || true
           
           # 全てのヒープブロックが解放されたかチェック
-          if grep -q "All heap blocks were freed -- no leaks are possible" valgrind_output.txt; then
+          if grep -q "All heap blocks were freed -- no leaks are possible" valgrind_prod.txt; then
             echo "✅ All heap blocks were freed"
-          elif grep -q "definitely lost: 0 bytes in 0 blocks" valgrind_output.txt && \
-               grep -q "indirectly lost: 0 bytes in 0 blocks" valgrind_output.txt && \
-               grep -q "possibly lost: 0 bytes in 0 blocks" valgrind_output.txt; then
+          elif grep -q "definitely lost: 0 bytes in 0 blocks" valgrind_prod.txt && \
+               grep -q "indirectly lost: 0 bytes in 0 blocks" valgrind_prod.txt && \
+               grep -q "possibly lost: 0 bytes in 0 blocks" valgrind_prod.txt; then
             echo "✅ No definite, indirect, or possible leaks"
           else
             echo "⚠️  Warning: Some reachable memory detected (this is usually OK for readline)"
@@ -98,16 +102,95 @@ jobs:
         fi
         EOF
         
-        chmod +x test_input.sh
+        chmod +x test_prod.sh
     
-    - name: Run memory leak test
+    - name: Create test script for development mode
       run: |
-        ./test_input.sh
+        cat << 'EOF' > test_dev.sh
+        #!/bin/bash
+        
+        echo ""
+        echo "=========================================="
+        echo "🔧 Testing DEVELOPMENT mode"
+        echo "=========================================="
+        
+        # minishellにコマンドを送信してメモリリークをチェック
+        echo "Starting memory leak test for development mode..."
+        
+        # expectスタイルでインタラクティブな入力をシミュレート
+        (
+          sleep 0.5
+          echo "ec'c'o \"hello\"&&cat -e"
+          sleep 0.5
+          echo "exit"
+          sleep 0.5
+        ) | valgrind --leak-check=full \
+                     --show-leak-kinds=all \
+                     --track-origins=yes \
+                     --suppressions=./readline.supp \
+                     --error-exitcode=42 \
+                     --log-file=valgrind_dev.txt \
+                     ./minishell --dev 2>&1
+        
+        VALGRIND_EXIT=$?
+        
+        echo ""
+        echo "=========================================="
+        echo "Valgrind Output (Development):"
+        echo "=========================================="
+        cat valgrind_dev.txt
+        echo "=========================================="
+        
+        # Valgrindの結果を解析
+        if [ $VALGRIND_EXIT -eq 42 ]; then
+          echo ""
+          echo "❌ MEMORY LEAK DETECTED in DEVELOPMENT mode!"
+          echo ""
+          echo "Summary of leaks:"
+          grep "definitely lost" valgrind_dev.txt || echo "No definitely lost blocks"
+          grep "indirectly lost" valgrind_dev.txt || echo "No indirectly lost blocks"
+          grep "possibly lost" valgrind_dev.txt || echo "No possibly lost blocks"
+          exit 1
+        else
+          echo ""
+          echo "✅ NO MEMORY LEAKS DETECTED in DEVELOPMENT mode"
+          
+          # リークサマリーを表示
+          echo ""
+          echo "Leak Summary:"
+          grep "LEAK SUMMARY" valgrind_dev.txt -A 5 || true
+          
+          # 全てのヒープブロックが解放されたかチェック
+          if grep -q "All heap blocks were freed -- no leaks are possible" valgrind_dev.txt; then
+            echo "✅ All heap blocks were freed"
+          elif grep -q "definitely lost: 0 bytes in 0 blocks" valgrind_dev.txt && \
+               grep -q "indirectly lost: 0 bytes in 0 blocks" valgrind_dev.txt && \
+               grep -q "possibly lost: 0 bytes in 0 blocks" valgrind_dev.txt; then
+            echo "✅ No definite, indirect, or possible leaks"
+          else
+            echo "⚠️  Warning: Some reachable memory detected (this is usually OK for readline)"
+          fi
+          
+          exit 0
+        fi
+        EOF
+        
+        chmod +x test_dev.sh
+    
+    - name: Run memory leak test (Production mode)
+      run: |
+        ./test_prod.sh
+    
+    - name: Run memory leak test (Development mode)
+      run: |
+        ./test_dev.sh
     
     - name: Upload valgrind output as artifact
       if: always()
       uses: actions/upload-artifact@v4
       with:
         name: valgrind-report
-        path: valgrind_output.txt
+        path: |
+          valgrind_prod.txt
+          valgrind_dev.txt
         retention-days: 30

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: urassh <urassh@student.42.fr>              +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2025/05/18 21:11:39 by kjikuhar          #+#    #+#              #
-#    Updated: 2025/11/26 17:01:03 by urassh           ###   ########.fr        #
+#    Updated: 2025/11/26 17:03:05 by urassh           ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -75,7 +75,7 @@ SRCS_MAND	:=	src/main.c \
 				src/component/heredoc/heredoc_prompt.c \
 				src/component/heredoc/tmpfile.c \
 				src/component/env_table/build_env_table.c \
-				src/component/env_table/export_env.c \
+				src/component/env_table/export_envp.c \
 
 #bonus sources
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: urassh <urassh@student.42.fr>              +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2025/05/18 21:11:39 by kjikuhar          #+#    #+#              #
-#    Updated: 2025/11/20 17:42:22 by urassh           ###   ########.fr        #
+#    Updated: 2025/11/26 17:01:03 by urassh           ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -60,7 +60,7 @@ SRCS_MAND	:=	src/main.c \
 				src/callback/on_input.c \
 				src/checker/tokenize_checker.c \
 				src/checker/heredoc_checker.c \
-				src/checker/exv_table_checker.c \
+				src/checker/env_table_checker.c \
 				src/tokenize/tokenize.c \
 				src/tokenize/is_specific.c \
 				src/tokenize/state/in_normal.c \

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ SRCS_MAND	:=	src/main.c \
 				src/callback/on_input.c \
 				src/checker/tokenize_checker.c \
 				src/checker/heredoc_checker.c \
+				src/checker/exv_table_checker.c \
 				src/tokenize/tokenize.c \
 				src/tokenize/is_specific.c \
 				src/tokenize/state/in_normal.c \
@@ -73,6 +74,8 @@ SRCS_MAND	:=	src/main.c \
 				src/component/heredoc/heredoc.c \
 				src/component/heredoc/heredoc_prompt.c \
 				src/component/heredoc/tmpfile.c \
+				src/component/env_table/build_env_table.c \
+				src/component/env_table/export_env.c \
 
 #bonus sources
 

--- a/includes/env_table.h
+++ b/includes/env_table.h
@@ -18,7 +18,7 @@
 
 # define ENV_TABLE_INIT_SIZE 256
 
-t_hash_table	*build_env_table(char **envp);
+t_hash_table	*build_env_table(char *const envp[]);
 char			**export_envp(t_hash_table *env_table);
 
 #endif

--- a/includes/env_table.h
+++ b/includes/env_table.h
@@ -1,0 +1,24 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   env_table.h                                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: urassh <urassh@student.42.fr>              +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/11/26 16:13:33 by urassh            #+#    #+#             */
+/*   Updated: 2025/11/26 16:31:31 by urassh           ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#ifndef ENV_TABLE_H
+# define ENV_TABLE_H
+
+# include <constants.h>
+# include <libft.h>
+
+# define ENV_TABLE_INIT_SIZE 256
+
+t_hash_table	*build_env_table(char **envp);
+char			**export_envp(t_hash_table *env_table);
+
+#endif

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -26,6 +26,6 @@ void	on_input(char *input, t_hash_table *env_table);
 // checkers
 void	tokenize_checker(char *input, t_hash_table *env_table);
 void	heredoc_checker(char *input, t_hash_table *env_table);
-void	env_table_checker(char *input, t_hash_table *env_table);
+void	env_table_checker(t_hash_table *env_table);
 
 #endif

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -20,7 +20,7 @@
 # include "heredoc.h"
 
 // callbacks
-void	on_input(char *input);
+void	on_input(char *input, t_hash_table *env);
 
 // checkers
 void	tokenize_checker(char *input);

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -26,5 +26,6 @@ void	on_input(char *input, t_hash_table *env_table);
 // checkers
 void	tokenize_checker(char *input, t_hash_table *env_table);
 void	heredoc_checker(char *input, t_hash_table *env_table);
+void	env_table_checker(char *input, t_hash_table *env_table);
 
 #endif

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: urassh <urassh@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/09/29 15:14:22 by kjikuhar          #+#    #+#             */
-/*   Updated: 2025/11/20 15:56:35 by urassh           ###   ########.fr       */
+/*   Updated: 2025/11/26 16:51:25 by urassh           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,16 +14,17 @@
 # define MINISHELL_H
 
 # include "constants.h"
+# include "env_table.h"
+# include "heredoc.h"
 # include "libft.h"
 # include "prompt.h"
 # include "tokenize.h"
-# include "heredoc.h"
 
 // callbacks
-void	on_input(char *input, t_hash_table *env);
+void	on_input(char *input, t_hash_table *env_table);
 
 // checkers
-void	tokenize_checker(char *input);
-void	heredoc_checker(char *input);
+void	tokenize_checker(char *input, t_hash_table *env_table);
+void	heredoc_checker(char *input, t_hash_table *env_table);
 
 #endif

--- a/includes/prompt.h
+++ b/includes/prompt.h
@@ -6,7 +6,7 @@
 /*   By: urassh <urassh@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/10/01 15:35:18 by urassh            #+#    #+#             */
-/*   Updated: 2025/10/16 23:15:29 by urassh           ###   ########.fr       */
+/*   Updated: 2025/11/26 16:02:45 by urassh           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,7 +20,8 @@
 # include <stdlib.h>
 # include <unistd.h>
 
-void	prompt(void (*handler)(char *input));
+void	prompt(void (*handler)(char *input, t_hash_table *env),
+			t_hash_table *env);
 
 # define PROMPT "minishell$ "
 

--- a/includes/prompt.h
+++ b/includes/prompt.h
@@ -6,7 +6,7 @@
 /*   By: urassh <urassh@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/10/01 15:35:18 by urassh            #+#    #+#             */
-/*   Updated: 2025/11/26 16:02:45 by urassh           ###   ########.fr       */
+/*   Updated: 2025/11/26 16:48:53 by urassh           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,8 +20,8 @@
 # include <stdlib.h>
 # include <unistd.h>
 
-void	prompt(void (*handler)(char *input, t_hash_table *env),
-			t_hash_table *env);
+void	prompt(void (*handler)(char *input, t_hash_table *env_table),
+			t_hash_table *env_table);
 
 # define PROMPT "minishell$ "
 

--- a/src/callback/on_input.c
+++ b/src/callback/on_input.c
@@ -6,14 +6,14 @@
 /*   By: urassh <urassh@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/10/10 17:04:25 by urassh            #+#    #+#             */
-/*   Updated: 2025/11/05 13:48:51 by urassh           ###   ########.fr       */
+/*   Updated: 2025/11/26 16:50:02 by urassh           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-void	on_input(char *input, t_hash_table *env)
+void	on_input(char *input, t_hash_table *env_table)
 {
-	(void)env;
+	(void)env_table;
 	free(input);
 }

--- a/src/callback/on_input.c
+++ b/src/callback/on_input.c
@@ -12,7 +12,8 @@
 
 #include "minishell.h"
 
-void	on_input(char *input)
+void	on_input(char *input, t_hash_table *env)
 {
+	(void)env;
 	free(input);
 }

--- a/src/checker/env_table_checker.c
+++ b/src/checker/env_table_checker.c
@@ -6,7 +6,7 @@
 /*   By: urassh <urassh@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/11/26 16:53:40 by urassh            #+#    #+#             */
-/*   Updated: 2025/11/26 17:00:37 by urassh           ###   ########.fr       */
+/*   Updated: 2025/11/26 17:04:38 by urassh           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,9 +16,8 @@
 static void	print_env_table_entries(t_hash_table *env_table);
 static void	print_exported_envp(t_hash_table *env_table);
 
-void	env_table_checker(char *input, t_hash_table *env_table)
+void	env_table_checker(t_hash_table *env_table)
 {
-	(void)input;
 	printf("\n========== ENV TABLE ENTRIES ==========\n");
 	print_env_table_entries(env_table);
 	printf("\n========== EXPORTED ENVP ==========\n");

--- a/src/checker/env_table_checker.c
+++ b/src/checker/env_table_checker.c
@@ -1,0 +1,78 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   env_table_checker.c                                :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: urassh <urassh@student.42.fr>              +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/11/26 16:53:40 by urassh            #+#    #+#             */
+/*   Updated: 2025/11/26 17:00:37 by urassh           ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <minishell.h>
+#include <stdio.h>
+
+static void	print_env_table_entries(t_hash_table *env_table);
+static void	print_exported_envp(t_hash_table *env_table);
+
+void	env_table_checker(char *input, t_hash_table *env_table)
+{
+	(void)input;
+	printf("\n========== ENV TABLE ENTRIES ==========\n");
+	print_env_table_entries(env_table);
+	printf("\n========== EXPORTED ENVP ==========\n");
+	print_exported_envp(env_table);
+	printf("=======================================\n\n");
+}
+
+static void	print_env_table_entries(t_hash_table *env_table)
+{
+	size_t		i;
+	t_hash_node	*node;
+
+	if (!env_table)
+	{
+		printf("env_table is NULL\n");
+		return ;
+	}
+	printf("Total entries: %zu\n", env_table->n_nodes);
+	printf("Table size: %zu\n\n", env_table->size);
+	i = 0;
+	while (i < env_table->size)
+	{
+		node = env_table->buckets[i];
+		while (node)
+		{
+			printf("[%zu] %s = %s\n", i, node->key, node->value);
+			node = node->next;
+		}
+		i++;
+	}
+}
+
+static void	print_exported_envp(t_hash_table *env_table)
+{
+	char	**envp;
+	size_t	i;
+
+	if (!env_table)
+	{
+		printf("env_table is NULL\n");
+		return ;
+	}
+	envp = export_envp(env_table);
+	if (!envp)
+	{
+		printf("Failed to export envp\n");
+		return ;
+	}
+	i = 0;
+	while (envp[i])
+	{
+		printf("%s\n", envp[i]);
+		free(envp[i]);
+		i++;
+	}
+	free(envp);
+}

--- a/src/checker/env_table_checker.c
+++ b/src/checker/env_table_checker.c
@@ -6,15 +6,18 @@
 /*   By: urassh <urassh@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/11/26 16:53:40 by urassh            #+#    #+#             */
-/*   Updated: 2025/11/26 17:04:38 by urassh           ###   ########.fr       */
+/*   Updated: 2025/11/26 17:29:16 by urassh           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <minishell.h>
 #include <stdio.h>
+#include <sys/wait.h>
+#include <unistd.h>
 
 static void	print_env_table_entries(t_hash_table *env_table);
 static void	print_exported_envp(t_hash_table *env_table);
+static void	test_execve_with_envp(t_hash_table *env_table);
 
 void	env_table_checker(t_hash_table *env_table)
 {
@@ -22,6 +25,8 @@ void	env_table_checker(t_hash_table *env_table)
 	print_env_table_entries(env_table);
 	printf("\n========== EXPORTED ENVP ==========\n");
 	print_exported_envp(env_table);
+	printf("\n========== EXECVE TEST ==========\n");
+	test_execve_with_envp(env_table);
 	printf("=======================================\n\n");
 }
 
@@ -74,4 +79,43 @@ static void	print_exported_envp(t_hash_table *env_table)
 		i++;
 	}
 	free(envp);
+}
+
+static void	free_envp(char **envp)
+{
+	char	**tmp;
+
+	tmp = envp;
+	while (*tmp)
+		free(*tmp++);
+	free(envp);
+}
+
+static void	test_execve_with_envp(t_hash_table *env_table)
+{
+	char	**envp;
+	pid_t	pid;
+	int		status;
+	char	*argv[2];
+
+	envp = export_envp(env_table);
+	if (!env_table || !envp)
+	{
+		printf("env_table is NULL or failed to export envp\n");
+		return ;
+	}
+	pid = fork();
+	if (pid == 0)
+	{
+		argv[0] = "/usr/bin/env";
+		argv[1] = NULL;
+		execve("/usr/bin/env", argv, envp);
+		perror("execve failed");
+		exit(1);
+	}
+	else if (pid > 0 && waitpid(pid, &status, 0) != -1 && WIFEXITED(status))
+		printf("execve test completed!!\n");
+	else
+		printf("\nFork failed or test terminated abnormally\n");
+	free_envp(envp);
 }

--- a/src/checker/heredoc_checker.c
+++ b/src/checker/heredoc_checker.c
@@ -6,7 +6,7 @@
 /*   By: urassh <urassh@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/11/20 15:55:55 by urassh            #+#    #+#             */
-/*   Updated: 2025/11/26 16:02:02 by urassh           ###   ########.fr       */
+/*   Updated: 2025/11/26 16:49:25 by urassh           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,12 +18,12 @@ static void	on_exit_token(t_list *token_list);
 static void	print_tokens(t_list *token_list);
 static void	unlink_tmpfiles(t_list *token_list);
 
-void	heredoc_checker(char *input, t_hash_table *env)
+void	heredoc_checker(char *input, t_hash_table *env_table)
 {
 	t_list	*token_list;
 	t_list	*heredoced_list;
 
-	(void)env;
+	(void)env_table;
 	token_list = tokenize(input);
 	if (!token_list)
 	{

--- a/src/checker/heredoc_checker.c
+++ b/src/checker/heredoc_checker.c
@@ -6,7 +6,7 @@
 /*   By: urassh <urassh@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/11/20 15:55:55 by urassh            #+#    #+#             */
-/*   Updated: 2025/11/20 17:40:53 by urassh           ###   ########.fr       */
+/*   Updated: 2025/11/26 16:02:02 by urassh           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,11 +18,12 @@ static void	on_exit_token(t_list *token_list);
 static void	print_tokens(t_list *token_list);
 static void	unlink_tmpfiles(t_list *token_list);
 
-void	heredoc_checker(char *input)
+void	heredoc_checker(char *input, t_hash_table *env)
 {
 	t_list	*token_list;
 	t_list	*heredoced_list;
 
+	(void)env;
 	token_list = tokenize(input);
 	if (!token_list)
 	{

--- a/src/checker/tokenize_checker.c
+++ b/src/checker/tokenize_checker.c
@@ -6,7 +6,7 @@
 /*   By: urassh <urassh@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/11/05 13:47:35 by urassh            #+#    #+#             */
-/*   Updated: 2025/11/26 16:02:29 by urassh           ###   ########.fr       */
+/*   Updated: 2025/11/26 16:49:18 by urassh           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,11 +15,11 @@
 static void	on_exit_token(t_list *token_list);
 static void	print_tokens(t_list *token_list);
 
-void	tokenize_checker(char *input, t_hash_table *env)
+void	tokenize_checker(char *input, t_hash_table *env_table)
 {
 	t_list	*token_list;
 
-	(void)env;
+	(void)env_table;
 	token_list = tokenize(input);
 	if (!token_list)
 	{

--- a/src/checker/tokenize_checker.c
+++ b/src/checker/tokenize_checker.c
@@ -6,7 +6,7 @@
 /*   By: urassh <urassh@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/11/05 13:47:35 by urassh            #+#    #+#             */
-/*   Updated: 2025/11/05 13:48:56 by urassh           ###   ########.fr       */
+/*   Updated: 2025/11/26 16:02:29 by urassh           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,10 +15,11 @@
 static void	on_exit_token(t_list *token_list);
 static void	print_tokens(t_list *token_list);
 
-void	tokenize_checker(char *input)
+void	tokenize_checker(char *input, t_hash_table *env)
 {
 	t_list	*token_list;
 
+	(void)env;
 	token_list = tokenize(input);
 	if (!token_list)
 	{

--- a/src/component/env_table/build_env_table.c
+++ b/src/component/env_table/build_env_table.c
@@ -1,0 +1,76 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   build_env_table.c                                  :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: urassh <urassh@student.42.fr>              +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/11/26 16:15:23 by urassh            #+#    #+#             */
+/*   Updated: 2025/11/26 16:31:37 by urassh           ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <env_table.h>
+
+static int		insert_env_entries(char **envp, t_hash_table *table);
+static int		parse_env_entry(char *env, char **key, char **value);
+
+t_hash_table	*build_env_table(char **envp)
+{
+	t_hash_table	*table;
+
+	if (!envp)
+		return (NULL);
+	table = ht_create(ENV_TABLE_INIT_SIZE);
+	if (!table)
+		return (NULL);
+	if (insert_env_entries(envp, table) == ERROR)
+		return (NULL);
+	return (table);
+}
+
+static int	insert_env_entries(char **envp, t_hash_table *table)
+{
+	size_t	i;
+	char	*key_tmp;
+	char	*value_tmp;
+
+	while (envp[i])
+	{
+		if (parse_env_entry(envp[i], &key_tmp, &value_tmp) == ERROR)
+			return (ERROR);
+		if (!ht_insert(table, key_tmp, value_tmp))
+		{
+			free(key_tmp);
+			free(value_tmp);
+			ht_destroy(table);
+			return (NULL);
+		}
+		free(key_tmp);
+		free(value_tmp);
+		i++;
+	}
+	return (SUCCESS);
+}
+
+static int	parse_env_entry(char *env, char **key, char **value)
+{
+	char	*eq_ptr;
+	size_t	key_len;
+
+	eq_ptr = ft_strchr(env, '=');
+	if (!eq_ptr)
+		return (ERROR);
+	key_len = eq_ptr - env;
+	*key = (char *)malloc(key_len + 1);
+	if (!*key)
+		return (ERROR);
+	ft_strlcpy(*key, env, key_len + 1);
+	*value = ft_strdup(eq_ptr + 1);
+	if (!*value)
+	{
+		free(*key);
+		return (ERROR);
+	}
+	return (SUCCESS);
+}

--- a/src/component/env_table/build_env_table.c
+++ b/src/component/env_table/build_env_table.c
@@ -35,6 +35,7 @@ static int	insert_env_entries(char **envp, t_hash_table *table)
 	char	*key_tmp;
 	char	*value_tmp;
 
+	i = 0;
 	while (envp[i])
 	{
 		if (parse_env_entry(envp[i], &key_tmp, &value_tmp) == ERROR)

--- a/src/component/env_table/build_env_table.c
+++ b/src/component/env_table/build_env_table.c
@@ -12,10 +12,10 @@
 
 #include <env_table.h>
 
-static int		insert_env_entries(char **envp, t_hash_table *table);
+static int		insert_env_entries(char *const envp[], t_hash_table *table);
 static int		parse_env_entry(char *env, char **key, char **value);
 
-t_hash_table	*build_env_table(char **envp)
+t_hash_table	*build_env_table(char *const envp[])
 {
 	t_hash_table	*table;
 
@@ -29,7 +29,7 @@ t_hash_table	*build_env_table(char **envp)
 	return (table);
 }
 
-static int	insert_env_entries(char **envp, t_hash_table *table)
+static int	insert_env_entries(char *const envp[], t_hash_table *table)
 {
 	size_t	i;
 	char	*key_tmp;

--- a/src/component/env_table/build_env_table.c
+++ b/src/component/env_table/build_env_table.c
@@ -6,7 +6,7 @@
 /*   By: urassh <urassh@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/11/26 16:15:23 by urassh            #+#    #+#             */
-/*   Updated: 2025/11/26 16:31:37 by urassh           ###   ########.fr       */
+/*   Updated: 2025/11/26 17:01:50 by urassh           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -44,7 +44,7 @@ static int	insert_env_entries(char **envp, t_hash_table *table)
 			free(key_tmp);
 			free(value_tmp);
 			ht_destroy(table);
-			return (NULL);
+			return (ERROR);
 		}
 		free(key_tmp);
 		free(value_tmp);

--- a/src/component/env_table/export_envp.c
+++ b/src/component/env_table/export_envp.c
@@ -82,6 +82,7 @@ static void	free_envp_array(char **envp, size_t count)
 	while (i < count)
 	{
 		free(envp[i]);
+		envp[i] = NULL;
 		i++;
 	}
 	free(envp);

--- a/src/component/env_table/export_envp.c
+++ b/src/component/env_table/export_envp.c
@@ -1,0 +1,88 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   export_envp.c                                      :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: urassh <urassh@student.42.fr>              +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/11/26 16:15:41 by urassh            #+#    #+#             */
+/*   Updated: 2025/11/26 16:45:48 by urassh           ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <env_table.h>
+
+static int	export_envp_entries(char **envp, t_hash_table *env_table);
+static char	*export_envp_str(t_hash_node *node);
+static void	free_envp_array(char **envp, size_t count);
+
+char	**export_envp(t_hash_table *env_table)
+{
+	char	**envp;
+
+	if (!env_table)
+		return (NULL);
+	envp = (char **)ft_calloc(env_table->n_nodes + 1, sizeof(char *));
+	if (!envp)
+		return (NULL);
+	if (export_envp_entries(envp, env_table) == ERROR)
+		return (NULL);
+	return (envp);
+}
+
+static int	export_envp_entries(char **envp, t_hash_table *env_table)
+{
+	size_t		index;
+	size_t		env_index;
+	t_hash_node	*node;
+
+	env_index = 0;
+	index = 0;
+	while (index < env_table->size)
+	{
+		node = env_table->buckets[index];
+		while (node)
+		{
+			envp[env_index] = export_envp_str(node);
+			if (!envp[env_index])
+			{
+				free_envp_array(envp, env_index);
+				return (ERROR);
+			}
+			env_index++;
+			node = node->next;
+		}
+		index++;
+	}
+	return (SUCCESS);
+}
+
+static char	*export_envp_str(t_hash_node *node)
+{
+	char	*result;
+	size_t	key_len;
+	size_t	value_len;
+
+	key_len = ft_strlen(node->key);
+	value_len = ft_strlen(node->value);
+	result = (char *)malloc(key_len + value_len + 2);
+	if (!result)
+		return (NULL);
+	ft_strlcpy(result, node->key, key_len + 1);
+	result[key_len] = '=';
+	ft_strlcpy(result + key_len + 1, node->value, value_len + 1);
+	return (result);
+}
+
+static void	free_envp_array(char **envp, size_t count)
+{
+	size_t	i;
+
+	i = 0;
+	while (i < count)
+	{
+		free(envp[i]);
+		i++;
+	}
+	free(envp);
+}

--- a/src/main.c
+++ b/src/main.c
@@ -6,14 +6,23 @@
 /*   By: urassh <urassh@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/09/29 15:13:47 by kjikuhar          #+#    #+#             */
-/*   Updated: 2025/10/15 01:50:50 by urassh           ###   ########.fr       */
+/*   Updated: 2025/11/26 16:01:45 by urassh           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-int	main(void)
+int	main(int argc, char **argv, char **envp)
 {
-	prompt(heredoc_checker);
+	t_hash_table	*env;
+
+	(void)argc;
+	(void)argv;
+	(void)envp;
+	env = ht_create(128);
+	if (!env)
+		return (1);
+	prompt(heredoc_checker, env);
+	ht_destroy(env);
 	return (0);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -6,13 +6,13 @@
 /*   By: urassh <urassh@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/09/29 15:13:47 by kjikuhar          #+#    #+#             */
-/*   Updated: 2025/11/26 16:51:41 by urassh           ###   ########.fr       */
+/*   Updated: 2025/11/26 17:03:43 by urassh           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-int	main(int argc, char **argv, char **envp)
+int main_prod(int argc, char **argv, char **envp)
 {
 	t_hash_table	*env_table;
 
@@ -21,7 +21,30 @@ int	main(int argc, char **argv, char **envp)
 	env_table = build_env_table(envp);
 	if (!env_table)
 		return (1);
+	prompt(on_input, env_table);
+	ht_destroy(env_table);
+	return (0);
+}
+
+int main_dev(int argc, char **argv, char **envp)
+{
+	t_hash_table	*env_table;
+
+	(void)argc;
+	(void)argv;
+	env_table = build_env_table(envp);
+	if (!env_table)
+		return (1);
+	env_table_checker(env_table);
 	prompt(heredoc_checker, env_table);
 	ht_destroy(env_table);
 	return (0);
+}
+
+int	main(int argc, char **argv, char **envp)
+{
+	if (argc > 1 && ft_strncmp(argv[1], "--dev", 6) == 0)
+		return (main_dev(argc, argv, envp));
+	else
+		return (main_prod(argc, argv, envp));
 }

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: urassh <urassh@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/09/29 15:13:47 by kjikuhar          #+#    #+#             */
-/*   Updated: 2025/11/26 16:01:45 by urassh           ###   ########.fr       */
+/*   Updated: 2025/11/26 16:51:41 by urassh           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,15 +14,14 @@
 
 int	main(int argc, char **argv, char **envp)
 {
-	t_hash_table	*env;
+	t_hash_table	*env_table;
 
 	(void)argc;
 	(void)argv;
-	(void)envp;
-	env = ht_create(128);
-	if (!env)
+	env_table = build_env_table(envp);
+	if (!env_table)
 		return (1);
-	prompt(heredoc_checker, env);
-	ht_destroy(env);
+	prompt(heredoc_checker, env_table);
+	ht_destroy(env_table);
 	return (0);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -12,7 +12,7 @@
 
 #include "minishell.h"
 
-int	main_prod(int argc, char **argv, char **envp)
+int	main_prod(int argc, char const **argv, char *const envp[])
 {
 	t_hash_table	*env_table;
 
@@ -26,7 +26,7 @@ int	main_prod(int argc, char **argv, char **envp)
 	return (0);
 }
 
-int	main_dev(int argc, char **argv, char **envp)
+int	main_dev(int argc, char const **argv, char *const envp[])
 {
 	t_hash_table	*env_table;
 
@@ -41,7 +41,7 @@ int	main_dev(int argc, char **argv, char **envp)
 	return (0);
 }
 
-int	main(int argc, char **argv, char **envp)
+int	main(int argc, char const **argv, char *const envp[])
 {
 	if (argc > 1 && ft_strncmp(argv[1], "--dev", 6) == 0)
 		return (main_dev(argc, argv, envp));

--- a/src/main.c
+++ b/src/main.c
@@ -6,13 +6,13 @@
 /*   By: urassh <urassh@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/09/29 15:13:47 by kjikuhar          #+#    #+#             */
-/*   Updated: 2025/11/26 17:03:43 by urassh           ###   ########.fr       */
+/*   Updated: 2025/11/26 17:27:11 by urassh           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-int main_prod(int argc, char **argv, char **envp)
+int	main_prod(int argc, char **argv, char **envp)
 {
 	t_hash_table	*env_table;
 
@@ -26,7 +26,7 @@ int main_prod(int argc, char **argv, char **envp)
 	return (0);
 }
 
-int main_dev(int argc, char **argv, char **envp)
+int	main_dev(int argc, char **argv, char **envp)
 {
 	t_hash_table	*env_table;
 

--- a/src/prompt/prompt.c
+++ b/src/prompt/prompt.c
@@ -6,13 +6,14 @@
 /*   By: urassh <urassh@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/10/01 15:35:00 by urassh            #+#    #+#             */
-/*   Updated: 2025/10/15 01:39:41 by urassh           ###   ########.fr       */
+/*   Updated: 2025/11/26 16:01:54 by urassh           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "prompt.h"
 
-void	prompt(void (*handler)(char *input))
+void	prompt(void (*handler)(char *input, t_hash_table *env),
+		t_hash_table *env)
 {
 	char	*input;
 
@@ -29,7 +30,7 @@ void	prompt(void (*handler)(char *input))
 		if (*input)
 			add_history(input);
 		if (handler)
-			handler(input);
+			handler(input, env);
 	}
 	rl_clear_history();
 }

--- a/src/prompt/prompt.c
+++ b/src/prompt/prompt.c
@@ -6,14 +6,14 @@
 /*   By: urassh <urassh@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/10/01 15:35:00 by urassh            #+#    #+#             */
-/*   Updated: 2025/11/26 16:01:54 by urassh           ###   ########.fr       */
+/*   Updated: 2025/11/26 16:50:17 by urassh           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "prompt.h"
 
-void	prompt(void (*handler)(char *input, t_hash_table *env),
-		t_hash_table *env)
+void	prompt(void (*handler)(char *input, t_hash_table *env_table),
+		t_hash_table *env_table)
 {
 	char	*input;
 
@@ -30,7 +30,7 @@ void	prompt(void (*handler)(char *input, t_hash_table *env),
 		if (*input)
 			add_history(input);
 		if (handler)
-			handler(input, env);
+			handler(input, env_table);
 	}
 	rl_clear_history();
 }


### PR DESCRIPTION
## やったこと
<!--
「このPRで何を実現したか」を一言で簡潔に列挙してください。
チームでの認識合わせのため、最初に目を通す人の「PRを読むモチベーション」になります。
- ~~~画面を追加しました
- ~~~API連携の処理をした。
-->
- envpからenv_tableを構築する機能を実装しました (`build_env_table`)
- env_tableからenvp形式にエクスポートする機能を実装しました (`export_envp`)
- main関数を本番モード (`main_prod`) と開発モード (`main_dev`) に分離しました
- env_tableの動作確認用チェッカーを追加しました (`env_table_checker`)
- GitHub Actionsのリークチェックを本番モード・開発モードの両方に対応させました

## 懸念点 / レビューしてほしいポイント
<!--
レビューの観点を明確にしておくと、レビュワーも的確なフィードバックができます。
「この書き方でよかったか不安」「stateの持ち方に自信がない」など、些細なことでもOKです。
-->
- `build_env_table`と`export_envp`のメモリ管理が適切か
- `parse_env_entry`でのエラーハンドリングが十分か
- env_tableのハッシュテーブルサイズ (`ENV_TABLE_INIT_SIZE = 256`) が適切か
- `env_table_checker`でforkを使ったexecveテストの実装方法

## 動作確認
<!--
自分の変更をレビュワーが動作チェックできるように書きましょう！

-->
- [x] norminetteを通過している。
- [x] makeコマンドでビルドできる。
- [x] valgrindでリークチェックをした。(`valgrind --leak-check=full --suppressions=readline.supp --show-leak-kinds=all -s -q ./minishell`)
- [x] 本番モード (`./minishell`) でメモリリークがない
- [x] 開発モード (`./minishell --dev`) でenv_tableの内容が正しく表示される
- [x] env_table_checkerでexecveテストが成功する
- [x] GitHub Actionsのリークチェックが両モードで通過する

## ひとこと
<!--
シンプルな感想を書きましょう！
-->
環境変数の管理基盤ができました！これでビルトインコマンドの実装に進めます。
