### PR TITLE
ディレクトリの検索関数を追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@
 #                                                         :::      ::::::::    #
 #    Makefile                                           :+:      :+:    :+:    #
 #                                                     +:+ +:+         +:+      #
-#    By: urassh <urassh@student.42.fr>              +#+  +:+       +#+         #
+#    By: surayama <surayama@student.42tokyo.jp>     +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2025/05/18 21:11:39 by kjikuhar          #+#    #+#              #
-#    Updated: 2025/11/27 14:58:00 by urassh           ###   ########.fr        #
+#    Updated: 2025/11/27 16:17:13 by surayama         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -62,6 +62,7 @@ SRCS_MAND	:=	src/main.c \
 				src/checker/heredoc_checker.c \
 				src/checker/shell_table_checker.c \
 				src/checker/parser_checker.c \
+				src/checker/directory_checker.c \
 				src/tokenize/tokenize.c \
 				src/tokenize/is_specific.c \
 				src/tokenize/state/in_normal.c \
@@ -94,6 +95,7 @@ SRCS_MAND	:=	src/main.c \
 				src/component/shell_table/export_envp.c \
 				src/component/pattern/filter_pattern.c \
 				src/component/directory/get_directory_entries.c \
+				src/component/directory/get_directory_all_entries.c \
 
 SRCS_BONUS	:=
 

--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,7 @@ SRCS_MAND	:=	src/main.c \
 				src/component/shell_table/build_shell_table.c \
 				src/component/shell_table/export_envp.c \
 				src/component/pattern/filter_pattern.c \
+				src/component/directory/get_directory_entries.c \
 
 SRCS_BONUS	:=
 

--- a/includes/directory.h
+++ b/includes/directory.h
@@ -6,17 +6,22 @@
 /*   By: surayama <surayama@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/11/27 15:25:07 by surayama          #+#    #+#             */
-/*   Updated: 2025/11/27 15:30:16 by surayama         ###   ########.fr       */
+/*   Updated: 2025/11/27 16:04:51 by surayama         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #ifndef DIRECTORY_H
 # define DIRECTORY_H
 
+# include <constants.h>
+# include <dirent.h>
+# include <errno.h>
 # include <libft.h>
 # include <stdbool.h>
+# include <stdlib.h>
+# include <sys/stat.h>
 
-int		get_directory_entries(const char *path, bool include_hidden,
-			t_list **entries);
+int	get_directory_entries(const char *path, bool include_hidden,
+		t_list **entries);
 
 #endif

--- a/includes/directory.h
+++ b/includes/directory.h
@@ -6,7 +6,7 @@
 /*   By: surayama <surayama@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/11/27 15:25:07 by surayama          #+#    #+#             */
-/*   Updated: 2025/11/27 16:04:51 by surayama         ###   ########.fr       */
+/*   Updated: 2025/11/27 16:08:52 by surayama         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,6 +22,8 @@
 # include <sys/stat.h>
 
 int	get_directory_entries(const char *path, bool include_hidden,
+		t_list **entries);
+int	get_directory_all_entries(const char *path, bool include_hidden,
 		t_list **entries);
 
 #endif

--- a/includes/directory.h
+++ b/includes/directory.h
@@ -1,23 +1,22 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   constants.h                                        :+:      :+:    :+:   */
+/*   directory.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: surayama <surayama@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2025/10/16 23:14:49 by urassh            #+#    #+#             */
-/*   Updated: 2025/11/27 15:26:31 by surayama         ###   ########.fr       */
+/*   Created: 2025/11/27 15:25:07 by surayama          #+#    #+#             */
+/*   Updated: 2025/11/27 15:30:16 by surayama         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#ifndef CONSTANTS_H
-# define CONSTANTS_H
+#ifndef DIRECTORY_H
+# define DIRECTORY_H
 
-// macros
-# define SUCCESS 0
-# define ERROR -1
-# define NOT_FOUND -2
-# define NO_PERMISSION -3
-# define NOT_A_DIRECTORY -4
+# include <libft.h>
+# include <stdbool.h>
+
+int		get_directory_entries(const char *path, bool include_hidden,
+			t_list **entries);
 
 #endif

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   minishell.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: urassh <urassh@student.42.fr>              +#+  +:+       +#+        */
+/*   By: surayama <surayama@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/09/29 15:14:22 by kjikuhar          #+#    #+#             */
-/*   Updated: 2025/11/27 14:54:45 by urassh           ###   ########.fr       */
+/*   Updated: 2025/11/27 16:11:07 by surayama         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,12 +14,12 @@
 # define MINISHELL_H
 
 # include "constants.h"
-# include "shell_table.h"
 # include "heredoc.h"
 # include "libft.h"
-# include "prompt.h"
-# include "tokenize.h"
 # include "parser.h"
+# include "prompt.h"
+# include "shell_table.h"
+# include "tokenize.h"
 
 // callbacks
 void	on_input(char *input, t_shell_table *shell_table);
@@ -29,4 +29,6 @@ void	tokenize_checker(char *input, t_shell_table *shell_table);
 void	heredoc_checker(char *input, t_shell_table *shell_table);
 void	shell_table_checker(t_shell_table *shell_table);
 void	parser_checker(char *input, t_shell_table *shell_table);
+void	directory_checker(char *input, t_shell_table *shell_table);
+
 #endif

--- a/libft/libft.h
+++ b/libft/libft.h
@@ -74,9 +74,9 @@ size_t				ft_min_size_t(size_t a, size_t b);
 
 // output
 void				ft_putchar_fd(char c, int fd);
-void				ft_putendl_fd(char *s, int fd);
+void				ft_putendl_fd(const char *s, int fd);
 void				ft_putnbr_fd(int n, int fd);
-void				ft_putstr_fd(char *s, int fd);
+void				ft_putstr_fd(const char *s, int fd);
 
 // string
 char				**ft_split(char const *s, char c);

--- a/libft/output/ft_putendl_fd.c
+++ b/libft/output/ft_putendl_fd.c
@@ -12,7 +12,7 @@
 
 #include "libft.h"
 
-void	ft_putendl_fd(char *s, int fd)
+void	ft_putendl_fd(const char *s, int fd)
 {
 	if (!s)
 		return ;

--- a/libft/output/ft_putstr_fd.c
+++ b/libft/output/ft_putstr_fd.c
@@ -12,7 +12,7 @@
 
 #include "libft.h"
 
-void	ft_putstr_fd(char *s, int fd)
+void	ft_putstr_fd(const char *s, int fd)
 {
 	if (!s)
 		return ;

--- a/src/checker/directory_checker.c
+++ b/src/checker/directory_checker.c
@@ -6,7 +6,7 @@
 /*   By: surayama <surayama@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/11/27 16:10:35 by surayama          #+#    #+#             */
-/*   Updated: 2025/11/27 16:16:25 by surayama         ###   ########.fr       */
+/*   Updated: 2025/11/27 16:40:38 by surayama         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,7 +22,6 @@ static void	test_all_entries(const char *input);
 void	directory_checker(char *input, t_shell_table *shell_table)
 {
 	(void)shell_table;
-
 	if (ft_strncmp(input, "exit", 5) == 0)
 	{
 		write(STDOUT_FILENO, "exit\n", 5);

--- a/src/checker/directory_checker.c
+++ b/src/checker/directory_checker.c
@@ -6,7 +6,7 @@
 /*   By: surayama <surayama@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/11/27 16:10:35 by surayama          #+#    #+#             */
-/*   Updated: 2025/11/27 16:40:38 by surayama         ###   ########.fr       */
+/*   Updated: 2025/11/27 16:42:07 by surayama         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,6 +25,7 @@ void	directory_checker(char *input, t_shell_table *shell_table)
 	if (ft_strncmp(input, "exit", 5) == 0)
 	{
 		write(STDOUT_FILENO, "exit\n", 5);
+		st_destroy(shell_table);
 		exit(0);
 	}
 	test_entries(input);

--- a/src/checker/directory_checker.c
+++ b/src/checker/directory_checker.c
@@ -25,12 +25,13 @@ void	directory_checker(char *input, t_shell_table *shell_table)
 	if (ft_strncmp(input, "exit", 5) == 0)
 	{
 		write(STDOUT_FILENO, "exit\n", 5);
+		rl_clear_history();
 		free(input);
-		st_destroy(shell_table);
 		exit(0);
 	}
 	test_entries(input);
 	test_all_entries(input);
+	free(input);
 }
 
 static void	test_entries(const char *input)

--- a/src/checker/directory_checker.c
+++ b/src/checker/directory_checker.c
@@ -1,0 +1,99 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   directory_checker.c                                :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: surayama <surayama@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/11/27 16:10:35 by surayama          #+#    #+#             */
+/*   Updated: 2025/11/27 16:16:25 by surayama         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <directory.h>
+#include <minishell.h>
+
+static void	print_entries(t_list *entries, const char *title);
+static void	test_function(const char *input, bool include_hidden,
+				int (*func)(const char *, bool, t_list **), const char *title);
+static void	test_entries(const char *input);
+static void	test_all_entries(const char *input);
+
+void	directory_checker(char *input, t_shell_table *shell_table)
+{
+	(void)shell_table;
+	test_entries(input);
+	test_all_entries(input);
+}
+
+static void	test_entries(const char *input)
+{
+	ft_putstr_fd("\n=== Testing get_directory_entries ===\n", 1);
+	ft_putstr_fd("Path: ", 1);
+	ft_putendl_fd(input, 1);
+	test_function(input, false, get_directory_entries,
+		"\n--- Without hidden files ---\nEntries");
+	test_function(input, true, get_directory_entries,
+		"\n--- With hidden files ---\nEntries");
+}
+
+static void	test_all_entries(const char *input)
+{
+	ft_putstr_fd("\n=== Testing get_directory_all_entries ===\n", 1);
+	ft_putstr_fd("Path: ", 1);
+	ft_putendl_fd(input, 1);
+	test_function(input, false, get_directory_all_entries,
+		"\n--- Without hidden files ---\nAll Entries (recursive)");
+	test_function(input, true, get_directory_all_entries,
+		"\n--- With hidden files ---\nAll Entries (recursive)");
+}
+
+static void	test_function(const char *input, bool include_hidden,
+		int (*func)(const char *, bool, t_list **), const char *title)
+{
+	t_list	*entries;
+	t_list	*tmp;
+	int		result;
+
+	result = func(input, include_hidden, &entries);
+	if (result != SUCCESS)
+	{
+		ft_putstr_fd("Error: ", 1);
+		if (result == NOT_FOUND)
+			ft_putendl_fd("Directory not found", 1);
+		else if (result == NO_PERMISSION)
+			ft_putendl_fd("Permission denied", 1);
+		else
+			ft_putendl_fd("Unknown error", 1);
+		return ;
+	}
+	print_entries(entries, title);
+	while (entries)
+	{
+		tmp = entries->next;
+		free(entries->content);
+		free(entries);
+		entries = tmp;
+	}
+}
+
+static void	print_entries(t_list *entries, const char *title)
+{
+	t_list	*current;
+	int		count;
+
+	ft_putstr_fd(title, 1);
+	ft_putstr_fd(":\n", 1);
+	count = 0;
+	current = entries;
+	while (current)
+	{
+		ft_putstr_fd("  - ", 1);
+		ft_putendl_fd((char *)current->content, 1);
+		current = current->next;
+		count++;
+	}
+	ft_putstr_fd("Total: ", 1);
+	ft_putnbr_fd(count, 1);
+	ft_putendl_fd(" entries", 1);
+}

--- a/src/checker/directory_checker.c
+++ b/src/checker/directory_checker.c
@@ -6,7 +6,7 @@
 /*   By: surayama <surayama@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/11/27 16:10:35 by surayama          #+#    #+#             */
-/*   Updated: 2025/11/27 16:42:07 by surayama         ###   ########.fr       */
+/*   Updated: 2025/11/27 16:45:10 by surayama         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,6 +25,7 @@ void	directory_checker(char *input, t_shell_table *shell_table)
 	if (ft_strncmp(input, "exit", 5) == 0)
 	{
 		write(STDOUT_FILENO, "exit\n", 5);
+		free(input);
 		st_destroy(shell_table);
 		exit(0);
 	}

--- a/src/checker/directory_checker.c
+++ b/src/checker/directory_checker.c
@@ -22,6 +22,12 @@ static void	test_all_entries(const char *input);
 void	directory_checker(char *input, t_shell_table *shell_table)
 {
 	(void)shell_table;
+
+	if (ft_strncmp(input, "exit", 5) == 0)
+	{
+		write(STDOUT_FILENO, "exit\n", 5);
+		exit(0);
+	}
 	test_entries(input);
 	test_all_entries(input);
 }

--- a/src/component/directory/get_directory_all_entries.c
+++ b/src/component/directory/get_directory_all_entries.c
@@ -1,0 +1,110 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   get_directory_all_entries.c                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: surayama <surayama@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/11/27 15:30:40 by surayama          #+#    #+#             */
+/*   Updated: 2025/11/27 16:08:41 by surayama         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <directory.h>
+
+static int	throw_error(void);
+static int	process_entry(const char *path, const char *name,
+				bool include_hidden, t_list **entries);
+static char	*join_path(const char *dir, const char *name);
+static int	read_directory_entries(DIR *dir, const char *path,
+				bool include_hidden, t_list **entries);
+
+int	get_directory_all_entries(const char *path, bool include_hidden,
+		t_list **entries)
+{
+	DIR	*dir;
+	int	result;
+
+	if (!entries)
+		return (ERROR);
+	*entries = NULL;
+	dir = opendir(path);
+	if (!dir)
+		return (throw_error());
+	result = read_directory_entries(dir, path, include_hidden, entries);
+	closedir(dir);
+	return (result);
+}
+
+static int	read_directory_entries(DIR *dir, const char *path,
+		bool include_hidden, t_list **entries)
+{
+	struct dirent	*entry;
+	int				result;
+
+	while (true)
+	{
+		entry = readdir(dir);
+		if (!entry)
+			break ;
+		if (!include_hidden && entry->d_name[0] == '.')
+			continue ;
+		result = process_entry(path, entry->d_name, include_hidden, entries);
+		if (result != SUCCESS)
+			return (result);
+	}
+	return (SUCCESS);
+}
+
+static int	process_entry(const char *path, const char *name,
+		bool include_hidden, t_list **entries)
+{
+	char		*full_path;
+	struct stat	st;
+	t_list		*sub_entries;
+	int			result;
+
+	full_path = join_path(path, name);
+	if (!full_path)
+		return (ERROR);
+	ft_lstadd_back(entries, ft_lstnew(ft_strdup(name)));
+	if (stat(full_path, &st) != 0 || !S_ISDIR(st.st_mode))
+	{
+		free(full_path);
+		return (SUCCESS);
+	}
+	if (ft_strncmp(name, ".", 2) == 0 || ft_strncmp(name, "..", 3) == 0)
+	{
+		free(full_path);
+		return (SUCCESS);
+	}
+	result = get_directory_entries(full_path, include_hidden, &sub_entries);
+	if (result == SUCCESS && sub_entries)
+		ft_lstadd_back(entries, sub_entries);
+	free(full_path);
+	return (SUCCESS);
+}
+
+static char	*join_path(const char *dir, const char *name)
+{
+	char	*temp;
+	char	*result;
+
+	temp = ft_strjoin(dir, "/");
+	if (!temp)
+		return (NULL);
+	result = ft_strjoin(temp, name);
+	free(temp);
+	return (result);
+}
+
+static int	throw_error(void)
+{
+	if (errno == ENOENT)
+		return (NOT_FOUND);
+	else if (errno == EACCES)
+		return (NO_PERMISSION);
+	else if (errno == ENOTDIR)
+		return (NOT_A_DIRECTORY);
+	return (ERROR);
+}

--- a/src/component/directory/get_directory_all_entries.c
+++ b/src/component/directory/get_directory_all_entries.c
@@ -94,6 +94,11 @@ static char	*join_path(const char *dir, const char *name)
 	if (!temp)
 		return (NULL);
 	result = ft_strjoin(temp, name);
+	if (!result)
+	{
+		free(temp);
+		return (NULL);
+	}
 	free(temp);
 	return (result);
 }

--- a/src/component/directory/get_directory_all_entries.c
+++ b/src/component/directory/get_directory_all_entries.c
@@ -67,7 +67,7 @@ static int	process_entry(const char *path, const char *name,
 	full_path = join_path(path, name);
 	if (!full_path)
 		return (ERROR);
-	ft_lstadd_back(entries, ft_lstnew(ft_strdup(name)));
+	ft_lstadd_back(entries, ft_lstnew(ft_strdup(full_path)));
 	if (stat(full_path, &st) != 0 || !S_ISDIR(st.st_mode))
 	{
 		free(full_path);
@@ -78,7 +78,7 @@ static int	process_entry(const char *path, const char *name,
 		free(full_path);
 		return (SUCCESS);
 	}
-	result = get_directory_entries(full_path, include_hidden, &sub_entries);
+	result = get_directory_all_entries(full_path, include_hidden, &sub_entries);
 	if (result == SUCCESS && sub_entries)
 		ft_lstadd_back(entries, sub_entries);
 	free(full_path);

--- a/src/component/directory/get_directory_entries.c
+++ b/src/component/directory/get_directory_entries.c
@@ -6,24 +6,19 @@
 /*   By: surayama <surayama@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/11/27 15:30:40 by surayama          #+#    #+#             */
-/*   Updated: 2025/11/27 16:04:54 by surayama         ###   ########.fr       */
+/*   Updated: 2025/11/27 16:08:26 by surayama         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <directory.h>
 
 static int	throw_error(void);
-static int	process_entry(const char *path, const char *name,
-				bool include_hidden, t_list **entries);
-static char	*join_path(const char *dir, const char *name);
-static int	read_directory_entries(DIR *dir, const char *path,
-				bool include_hidden, t_list **entries);
 
 int	get_directory_entries(const char *path, bool include_hidden,
 		t_list **entries)
 {
-	DIR	*dir;
-	int	result;
+	DIR				*dir;
+	struct dirent	*entry;
 
 	if (!entries)
 		return (ERROR);
@@ -31,17 +26,6 @@ int	get_directory_entries(const char *path, bool include_hidden,
 	dir = opendir(path);
 	if (!dir)
 		return (throw_error());
-	result = read_directory_entries(dir, path, include_hidden, entries);
-	closedir(dir);
-	return (result);
-}
-
-static int	read_directory_entries(DIR *dir, const char *path,
-		bool include_hidden, t_list **entries)
-{
-	struct dirent	*entry;
-	int				result;
-
 	while (true)
 	{
 		entry = readdir(dir);
@@ -49,53 +33,10 @@ static int	read_directory_entries(DIR *dir, const char *path,
 			break ;
 		if (!include_hidden && entry->d_name[0] == '.')
 			continue ;
-		result = process_entry(path, entry->d_name, include_hidden, entries);
-		if (result != SUCCESS)
-			return (result);
+		ft_lstadd_back(entries, ft_lstnew(ft_strdup(entry->d_name)));
 	}
+	closedir(dir);
 	return (SUCCESS);
-}
-
-static int	process_entry(const char *path, const char *name,
-		bool include_hidden, t_list **entries)
-{
-	char		*full_path;
-	struct stat	st;
-	t_list		*sub_entries;
-	int			result;
-
-	full_path = join_path(path, name);
-	if (!full_path)
-		return (ERROR);
-	ft_lstadd_back(entries, ft_lstnew(ft_strdup(name)));
-	if (stat(full_path, &st) != 0 || !S_ISDIR(st.st_mode))
-	{
-		free(full_path);
-		return (SUCCESS);
-	}
-	if (ft_strncmp(name, ".", 2) == 0 || ft_strncmp(name, "..", 3) == 0)
-	{
-		free(full_path);
-		return (SUCCESS);
-	}
-	result = get_directory_entries(full_path, include_hidden, &sub_entries);
-	if (result == SUCCESS && sub_entries)
-		ft_lstadd_back(entries, sub_entries);
-	free(full_path);
-	return (SUCCESS);
-}
-
-static char	*join_path(const char *dir, const char *name)
-{
-	char	*temp;
-	char	*result;
-
-	temp = ft_strjoin(dir, "/");
-	if (!temp)
-		return (NULL);
-	result = ft_strjoin(temp, name);
-	free(temp);
-	return (result);
 }
 
 static int	throw_error(void)

--- a/src/component/directory/get_directory_entries.c
+++ b/src/component/directory/get_directory_entries.c
@@ -6,13 +6,14 @@
 /*   By: surayama <surayama@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/11/27 15:30:40 by surayama          #+#    #+#             */
-/*   Updated: 2025/11/27 16:08:26 by surayama         ###   ########.fr       */
+/*   Updated: 2025/11/29 20:05:20 by surayama         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <directory.h>
 
 static int	throw_error(void);
+static int	append_entry(t_list **entries, const char *entry_name);
 
 int	get_directory_entries(const char *path, bool include_hidden,
 		t_list **entries)
@@ -33,7 +34,11 @@ int	get_directory_entries(const char *path, bool include_hidden,
 			break ;
 		if (!include_hidden && entry->d_name[0] == '.')
 			continue ;
-		ft_lstadd_back(entries, ft_lstnew(ft_strdup(entry->d_name)));
+		if (append_entry(entries, entry->d_name) == ERROR)
+		{
+			closedir(dir);
+			return (ERROR);
+		}
 	}
 	closedir(dir);
 	return (SUCCESS);
@@ -48,4 +53,15 @@ static int	throw_error(void)
 	else if (errno == ENOTDIR)
 		return (NOT_A_DIRECTORY);
 	return (ERROR);
+}
+
+static int	append_entry(t_list **entries, const char *entry_name)
+{
+	t_list	*entry_node;
+
+	entry_node = ft_lstnew(ft_strdup(entry_name));
+	if (!entry_node)
+		return (ERROR);
+	ft_lstadd_back(entries, entry_node);
+	return (SUCCESS);
 }

--- a/src/component/directory/get_directory_entries.c
+++ b/src/component/directory/get_directory_entries.c
@@ -1,0 +1,54 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   get_directory_entries.c                            :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: surayama <surayama@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/11/27 15:30:40 by surayama          #+#    #+#             */
+/*   Updated: 2025/11/27 15:40:07 by surayama         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <constants.h>
+#include <directory.h>
+#include <dirent.h>
+#include <errno.h>
+
+static int	throw_error(void);
+
+int	get_directory_entries(const char *path, bool include_hidden,
+		t_list **entries)
+{
+	DIR				*dir;
+	struct dirent	*entry;
+
+	if (!entries)
+		return (ERROR);
+	*entries = NULL;
+	dir = opendir(path);
+	if (!dir)
+		return (throw_error());
+	while (true)
+	{
+		entry = readdir(dir);
+		if (!entry)
+			break ;
+		if (!include_hidden && entry->d_name[0] == '.')
+			continue ;
+		ft_lstadd_back(entries, ft_lstnew(ft_strdup(entry->d_name)));
+	}
+	closedir(dir);
+	return (SUCCESS);
+}
+
+static int	throw_error(void)
+{
+	if (errno == ENOENT)
+		return (NOT_FOUND);
+	else if (errno == EACCES)
+		return (NO_PERMISSION);
+	else if (errno == ENOTDIR)
+		return (NOT_A_DIRECTORY);
+	return (ERROR);
+}

--- a/src/component/directory/get_directory_entries.c
+++ b/src/component/directory/get_directory_entries.c
@@ -6,22 +6,24 @@
 /*   By: surayama <surayama@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/11/27 15:30:40 by surayama          #+#    #+#             */
-/*   Updated: 2025/11/27 15:40:07 by surayama         ###   ########.fr       */
+/*   Updated: 2025/11/27 16:04:54 by surayama         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include <constants.h>
 #include <directory.h>
-#include <dirent.h>
-#include <errno.h>
 
 static int	throw_error(void);
+static int	process_entry(const char *path, const char *name,
+				bool include_hidden, t_list **entries);
+static char	*join_path(const char *dir, const char *name);
+static int	read_directory_entries(DIR *dir, const char *path,
+				bool include_hidden, t_list **entries);
 
 int	get_directory_entries(const char *path, bool include_hidden,
 		t_list **entries)
 {
-	DIR				*dir;
-	struct dirent	*entry;
+	DIR	*dir;
+	int	result;
 
 	if (!entries)
 		return (ERROR);
@@ -29,6 +31,17 @@ int	get_directory_entries(const char *path, bool include_hidden,
 	dir = opendir(path);
 	if (!dir)
 		return (throw_error());
+	result = read_directory_entries(dir, path, include_hidden, entries);
+	closedir(dir);
+	return (result);
+}
+
+static int	read_directory_entries(DIR *dir, const char *path,
+		bool include_hidden, t_list **entries)
+{
+	struct dirent	*entry;
+	int				result;
+
 	while (true)
 	{
 		entry = readdir(dir);
@@ -36,10 +49,53 @@ int	get_directory_entries(const char *path, bool include_hidden,
 			break ;
 		if (!include_hidden && entry->d_name[0] == '.')
 			continue ;
-		ft_lstadd_back(entries, ft_lstnew(ft_strdup(entry->d_name)));
+		result = process_entry(path, entry->d_name, include_hidden, entries);
+		if (result != SUCCESS)
+			return (result);
 	}
-	closedir(dir);
 	return (SUCCESS);
+}
+
+static int	process_entry(const char *path, const char *name,
+		bool include_hidden, t_list **entries)
+{
+	char		*full_path;
+	struct stat	st;
+	t_list		*sub_entries;
+	int			result;
+
+	full_path = join_path(path, name);
+	if (!full_path)
+		return (ERROR);
+	ft_lstadd_back(entries, ft_lstnew(ft_strdup(name)));
+	if (stat(full_path, &st) != 0 || !S_ISDIR(st.st_mode))
+	{
+		free(full_path);
+		return (SUCCESS);
+	}
+	if (ft_strncmp(name, ".", 2) == 0 || ft_strncmp(name, "..", 3) == 0)
+	{
+		free(full_path);
+		return (SUCCESS);
+	}
+	result = get_directory_entries(full_path, include_hidden, &sub_entries);
+	if (result == SUCCESS && sub_entries)
+		ft_lstadd_back(entries, sub_entries);
+	free(full_path);
+	return (SUCCESS);
+}
+
+static char	*join_path(const char *dir, const char *name)
+{
+	char	*temp;
+	char	*result;
+
+	temp = ft_strjoin(dir, "/");
+	if (!temp)
+		return (NULL);
+	result = ft_strjoin(temp, name);
+	free(temp);
+	return (result);
 }
 
 static int	throw_error(void)

--- a/src/main.c
+++ b/src/main.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   main.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: urassh <urassh@student.42.fr>              +#+  +:+       +#+        */
+/*   By: surayama <surayama@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/09/29 15:13:47 by kjikuhar          #+#    #+#             */
-/*   Updated: 2025/11/27 14:54:45 by urassh           ###   ########.fr       */
+/*   Updated: 2025/11/27 16:16:45 by surayama         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -36,7 +36,7 @@ int	main_dev(int argc, char const **argv, char *const envp[])
 	if (!shell_table)
 		return (1);
 	shell_table_checker(shell_table);
-	prompt(parser_checker, shell_table);
+	prompt(directory_checker, shell_table);
 	st_destroy(shell_table);
 	return (0);
 }


### PR DESCRIPTION
# ディレクトリの検索関数を追加

## やったこと
<!--
「このPRで何を実現したか」を一言で簡潔に列挙してください。
チームでの認識合わせのため、最初に目を通す人の「PRを読むモチベーション」になります。
- ~~~画面を追加しました
- ~~~API連携の処理をした。
-->
- ディレクトリ内のエントリを取得する関数を追加しました(`get_directory_entries`)
- ディレクトリ内のすべてのエントリを再帰的に取得する関数を追加しました(`get_directory_all_entries`)
- ディレクトリ関連のエラーコード定数を追加しました(`NOT_FOUND`, `NO_PERMISSION`, `NOT_A_DIRECTORY`)
- ディレクトリ機能のテストチェッカーを実装しました

## 懸念点 / レビューしてほしいポイント
<!--
レビューの観点を明確にしておくと、レビュワーも的確なフィードバックができます。
「この書き方でよかったか不安」「stateの持ち方に自信がない」など、些細なことでもOKです。
-->
- `get_directory_all_entries`の再帰処理でメモリリークが発生していないか
- エラーハンドリング(`errno`の処理)が適切か
- パスの結合処理(`join_path`)でメモリ管理が正しく行われているか
- 隠しファイルのフィルタリングロジックが要件を満たしているか

## 動作確認
<!--
自分の変更をレビュワーが動作チェックできるように書きましょう！

-->
- [] norminetteを通過している。
- [] makeコマンドでビルドできる。
- [] valgrindでリークチェックをした。(`valgrind --leak-check=full --suppressions=readline.supp --show-leak-kinds=all -s -q ./minishell`)
- [] `directory_checker`で様々なディレクトリパスに対してテストを実行し、正しくエントリが取得できることを確認
- [] 存在しないディレクトリや権限のないディレクトリに対して適切なエラーコードが返されることを確認
- [] 隠しファイルを含む/含まないオプションで正しくフィルタリングされることを確認

## 主な変更内容

### 新規追加ファイル
- `includes/directory.h`: ディレクトリ検索機能のヘッダーファイル
- `src/component/directory/get_directory_entries.c`: 指定ディレクトリ直下のエントリを取得
- `src/component/directory/get_directory_all_entries.c`: 指定ディレクトリ以下のすべてのエントリを再帰的に取得
- `src/checker/directory_checker.c`: ディレクトリ機能のテストチェッカー

### 修正ファイル
- `includes/constants.h`: エラーコード定数を追加
- `includes/minishell.h`: `directory_checker`関数を追加
- `libft/libft.h`, `libft/output/ft_putstr_fd.c`, `libft/output/ft_putendl_fd.c`: `const`修飾子を追加
- `Makefile`: 新規ソースファイルをビルド対象に追加

## 実装の詳細

### `get_directory_entries`
- 指定されたパス直下のエントリ名のみを取得
- `include_hidden`フラグで隠しファイルの表示/非表示を制御
- エラー時は適切なエラーコード(`NOT_FOUND`, `NO_PERMISSION`, `NOT_A_DIRECTORY`)を返却

### `get_directory_all_entries`
- 指定されたパス以下のすべてのエントリをフルパスで再帰的に取得
- ディレクトリの場合は再帰的に探索(`.`と`..`は除外)
- エントリのリストをリンクリスト(`t_list`)で返却

## ひとこと
<!--
シンプルな感想を書きましょう！
-->
ディレクトリ検索の基礎機能を実装しました。glob展開やワイルドカード処理の基盤として使えると思います!
