### PR TITLE
① echoコマンドを実装した

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ LIBFT_A		:=	$(LIBFT_DIR)/libft.a
 
 #mandatory sources
 SRCS_MAND	:=	src/main.c \
+				src/builtin/echo.c \
 				src/prompt/prompt.c \
 				src/callback/on_input.c \
 				src/checker/tokenize_checker.c \

--- a/includes/builtin.h
+++ b/includes/builtin.h
@@ -6,7 +6,7 @@
 /*   By: surayama <surayama@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/11/29 17:16:51 by surayama          #+#    #+#             */
-/*   Updated: 2025/11/29 17:17:38 by surayama         ###   ########.fr       */
+/*   Updated: 2025/11/29 18:09:29 by surayama         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,6 +14,7 @@
 # define BUILTIN_H
 
 # include <shell_table.h>
+# include <stdio.h>
 
 int	echo(t_list *argv, t_shell_table *shell_table);
 

--- a/includes/builtin.h
+++ b/includes/builtin.h
@@ -1,0 +1,20 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   builtin.h                                          :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: surayama <surayama@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/11/29 17:16:51 by surayama          #+#    #+#             */
+/*   Updated: 2025/11/29 17:17:38 by surayama         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#ifndef BUILTIN_H
+# define BUILTIN_H
+
+# include <shell_table.h>
+
+int	echo(t_list *argv, t_shell_table *shell_table);
+
+#endif

--- a/src/builtin/echo.c
+++ b/src/builtin/echo.c
@@ -12,7 +12,7 @@
 
 #include <builtin.h>
 
-static void	consume_head_node(t_list **argv);
+static void	skip_head_node(t_list **argv);
 static bool	check_n_option(t_list *argv);
 static void	print_argv(t_list *to_print_argv, bool with_newline);
 
@@ -25,18 +25,18 @@ int	echo(t_list *argv, t_shell_table *shell_table)
 	(void)shell_table;
 	echo_argv = argv;
 	with_newline = true;
-	consume_head_node(&echo_argv);
+	skip_head_node(&echo_argv);
 	use_n_option = check_n_option(echo_argv);
 	if (use_n_option)
 	{
 		with_newline = false;
-		consume_head_node(&echo_argv);
+		skip_head_node(&echo_argv);
 	}
 	print_argv(echo_argv, with_newline);
 	return (0);
 }
 
-static void	consume_head_node(t_list **argv)
+static void	skip_head_node(t_list **argv)
 {
 	if (argv && *argv)
 		*argv = (*argv)->next;

--- a/src/builtin/echo.c
+++ b/src/builtin/echo.c
@@ -6,28 +6,26 @@
 /*   By: surayama <surayama@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/11/29 17:16:37 by surayama          #+#    #+#             */
-/*   Updated: 2025/11/29 18:08:49 by surayama         ###   ########.fr       */
+/*   Updated: 2025/12/01 00:10:08 by surayama         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <builtin.h>
 
 static void	skip_head_node(t_list **argv);
-static bool	check_n_option(t_list *argv);
+static bool	is_n_option(t_list *argv);
 static void	print_argv(t_list *to_print_argv, bool with_newline);
 
 int	echo(t_list *argv, t_shell_table *shell_table)
 {
 	t_list	*echo_argv;
-	bool	use_n_option;
 	bool	with_newline;
 
 	(void)shell_table;
 	echo_argv = argv;
 	with_newline = true;
 	skip_head_node(&echo_argv);
-	use_n_option = check_n_option(echo_argv);
-	if (use_n_option)
+	while (is_n_option(echo_argv))
 	{
 		with_newline = false;
 		skip_head_node(&echo_argv);
@@ -42,7 +40,7 @@ static void	skip_head_node(t_list **argv)
 		*argv = (*argv)->next;
 }
 
-static bool	check_n_option(t_list *argv)
+static bool	is_n_option(t_list *argv)
 {
 	t_list	*option_node;
 	char	*str;

--- a/src/builtin/echo.c
+++ b/src/builtin/echo.c
@@ -6,7 +6,7 @@
 /*   By: surayama <surayama@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/11/29 17:16:37 by surayama          #+#    #+#             */
-/*   Updated: 2025/11/29 18:07:31 by surayama         ###   ########.fr       */
+/*   Updated: 2025/11/29 18:08:49 by surayama         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,7 +18,6 @@ static void	print_argv(t_list *to_print_argv, bool with_newline);
 
 int	echo(t_list *argv, t_shell_table *shell_table)
 {
-	t_list	*current;
 	t_list	*echo_argv;
 	bool	use_n_option;
 	bool	with_newline;

--- a/src/builtin/echo.c
+++ b/src/builtin/echo.c
@@ -1,0 +1,86 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   echo.c                                             :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: surayama <surayama@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/11/29 17:16:37 by surayama          #+#    #+#             */
+/*   Updated: 2025/11/29 17:38:25 by surayama         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <builtin.h>
+
+static void	consume_head_node(t_list **argv);
+static bool	check_n_option(t_list *argv);
+static void	print_argv(t_list *to_print_argv, bool with_newline);
+
+
+int	echo(t_list *argv, t_shell_table *shell_table)
+{
+	t_list	*current;
+	t_list	*echo_argv;
+	bool	use_n_option;
+	bool	with_newline;
+
+	(void)shell_table;
+	echo_argv = argv;
+	with_newline = true;
+	consume_head_node(&echo_argv);
+	use_n_option = check_n_option(echo_argv);
+	if (use_n_option)
+	{
+		with_newline = false;
+		consume_head_node(&echo_argv);
+	}
+	print_argv(echo_argv, with_newline);
+	return (0);
+}
+
+static void	consume_head_node(t_list **argv)
+{
+	if (argv && *argv)
+		*argv = (*argv)->next;
+}
+
+static bool	check_n_option(t_list *argv)
+{
+	t_list	*option_node;
+	char	*str;
+	int		i;
+
+	option_node = argv;
+	if (!option_node || !option_node->content)
+		return (false);
+	str = (char *)option_node->content;
+	if (str[0] != '-' || str[1] == '\0')
+		return (false);
+	i = 1;
+	while (str[i])
+	{
+		if (str[i] != 'n')
+			return (false);
+		i++;
+	}
+	return (true);
+}
+
+static void	print_argv(t_list *to_print_argv, bool with_newline)
+{
+	t_list	*current;
+
+	current = to_print_argv;
+	while (current)
+	{
+		if (current->content)
+		{
+			printf("%s", (char *)current->content);
+			if (current->next)
+				printf(" ");
+		}
+		current = current->next;
+	}
+	if (with_newline)
+		printf("\n");
+}

--- a/src/builtin/echo.c
+++ b/src/builtin/echo.c
@@ -6,7 +6,7 @@
 /*   By: surayama <surayama@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/11/29 17:16:37 by surayama          #+#    #+#             */
-/*   Updated: 2025/11/29 17:38:25 by surayama         ###   ########.fr       */
+/*   Updated: 2025/11/29 18:07:31 by surayama         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,7 +15,6 @@
 static void	consume_head_node(t_list **argv);
 static bool	check_n_option(t_list *argv);
 static void	print_argv(t_list *to_print_argv, bool with_newline);
-
 
 int	echo(t_list *argv, t_shell_table *shell_table)
 {


### PR DESCRIPTION
## やったこと
<!--
「このPRで何を実現したか」を一言で簡潔に列挙してください。
チームでの認識合わせのため、最初に目を通す人の「PRを読むモチベーション」になります。
- ~~~画面を追加しました
- ~~~API連携の処理をした。
-->
- echoビルトインコマンドを実装しました
- builtin.hヘッダーファイルを新規作成しました
- Makefileにecho.cを追加しました 

## 懸念点 / レビューしてほしいポイント
<!--
レビューの観点を明確にしておくと、レビュワーも的確なフィードバックができます。
「この書き方でよかったか不安」「stateの持ち方に自信がない」など、些細なことでもOKです。
-->
- echo関数の引数の型（t_listとt_shell_table）が適切か確認してほしい
- -nオプションの判定ロジックが正しいか（複数のnが続く場合の処理）
- ビルトイン関数の戻り値（0固定）で良いか 

## 動作確認
<!--
自分の変更をレビュワーが動作チェックできるように書きましょう！

-->
- [] norminetteを通過している。
- [] makeコマンドでビルドできる。
- [] valgrindでリークチェックをした。(`valgrind --leak-check=full --suppressions=readline.supp --show-leak-kinds=all -s -q ./minishell`)
- [] echoコマンドが引数なしで実行できる（改行のみ出力）
- [] echo "hello world" で文字列が正しく出力される
- [] echo -n "hello" で改行なしで出力される
- [] echo -nnn "test" で複数のnオプションが正しく処理される
- [] echo -n -n "test" で複数の-nオプションが正しく処理される
- [] echo -x "test" で無効なオプションが引数として扱われる

## 実装したechoの仕様

### 基本動作
- `echo [引数...]` の形式で引数を標準出力に表示
- 複数の引数がある場合はスペース区切りで出力
- デフォルトでは最後に改行を出力

### -nオプション
- `-n` オプションが指定された場合、末尾の改行を出力しない
- `-nnn` のように複数のnが続く場合も有効な-nオプションとして扱う
- `-n` 以外の文字が含まれる場合（例：`-nx`）は通常の引数として扱う

### 引数なしの場合
- 引数が何もない場合は改行のみを出力

## ひとこと
<!--
シンプルな感想を書きましょう！
-->
初回のビルトインコマンド実装で、bashのecho仕様をしっかり調べながら実装できました！-nオプションの処理が少し複雑でしたが、テストケースを考えながら実装できてよかったです。
