### PR TITLE
Tokenizeでダブルとシングルのクォートの区別が必要なことに気がついたのでその修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,8 @@ SRCS_MAND	:=	src/main.c \
 				src/tokenize/tokenize.c \
 				src/tokenize/is_specific.c \
 				src/tokenize/state/in_normal.c \
-				src/tokenize/state/in_quote.c \
+				src/tokenize/state/in_double_quote.c \
+				src/tokenize/state/in_single_quote.c \
 				src/tokenize/state/in_operator.c \
 				src/tokenize/state/on_success.c \
 				src/tokenize/state/on_error.c \

--- a/includes/tokenize.h
+++ b/includes/tokenize.h
@@ -20,7 +20,8 @@
 typedef enum e_token_state
 {
 	IN_NORMAL,
-	IN_QUOTE,
+	IN_DOUBLE_QUOTE,
+	IN_SINGLE_QUOTE,
 	IN_OPERATOR,
 	ON_SUCCESS,
 	ON_ERROR,
@@ -46,7 +47,9 @@ void		free_store(t_token_store *store);
 // state handler
 void		in_normal(t_token_store *store, t_token_state *state,
 				const char current);
-void		in_quote(t_token_store *store, t_token_state *state,
+void		in_double_quote(t_token_store *store, t_token_state *state,
+				const char current);
+void		in_single_quote(t_token_store *store, t_token_state *state,
 				const char current);
 void		in_operator(t_token_store *store, t_token_state *state,
 				const char current);

--- a/src/main.c
+++ b/src/main.c
@@ -36,7 +36,7 @@ int	main_dev(int argc, char const **argv, char *const envp[])
 	if (!shell_table)
 		return (1);
 	shell_table_checker(shell_table);
-	prompt(path_checker, shell_table);
+	prompt(tokenize_checker, shell_table);
 	st_destroy(shell_table);
 	return (0);
 }

--- a/src/tokenize/state/in_double_quote.c
+++ b/src/tokenize/state/in_double_quote.c
@@ -1,23 +1,24 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   in_quote.c                                         :+:      :+:    :+:   */
+/*   in_double_quote.c                                  :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: urassh <urassh@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2025/11/05 13:54:52 by urassh            #+#    #+#             */
-/*   Updated: 2025/11/05 14:21:31 by urassh           ###   ########.fr       */
+/*   Created: 2025/12/06 00:00:00 by urassh            #+#    #+#             */
+/*   Updated: 2025/12/06 00:00:00 by urassh           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "tokenize.h"
 
-void	in_quote(t_token_store *store, t_token_state *state, const char current)
+void	in_double_quote(t_token_store *store, t_token_state *state,
+		const char current)
 {
 	if (current == '\0')
 		*state = ON_ERROR;
 	else if (add_buffer(store, current) == ERROR)
 		*state = ON_ERROR;
-	else if (is_quote(current))
+	else if (current == '"')
 		*state = IN_NORMAL;
 }

--- a/src/tokenize/state/in_normal.c
+++ b/src/tokenize/state/in_normal.c
@@ -68,9 +68,10 @@ static void	by_operator(t_token_store *store, t_token_state *state,
 static void	by_quote(t_token_store *store, t_token_state *state,
 		const char current)
 {
-	(void)store;
 	if (add_buffer(store, current) == ERROR)
 		*state = ON_ERROR;
-	else
-		*state = IN_QUOTE;
+	else if (current == '"')
+		*state = IN_DOUBLE_QUOTE;
+	else if (current == '\'')
+		*state = IN_SINGLE_QUOTE;
 }

--- a/src/tokenize/state/in_single_quote.c
+++ b/src/tokenize/state/in_single_quote.c
@@ -1,0 +1,24 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   in_single_quote.c                                  :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: urassh <urassh@student.42.fr>              +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/12/06 00:00:00 by urassh            #+#    #+#             */
+/*   Updated: 2025/12/06 00:00:00 by urassh           ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "tokenize.h"
+
+void	in_single_quote(t_token_store *store, t_token_state *state,
+		const char current)
+{
+	if (current == '\0')
+		*state = ON_ERROR;
+	else if (add_buffer(store, current) == ERROR)
+		*state = ON_ERROR;
+	else if (current == '\'')
+		*state = IN_NORMAL;
+}

--- a/src/tokenize/tokenize.c
+++ b/src/tokenize/tokenize.c
@@ -28,8 +28,10 @@ t_list	*tokenize(char *input)
 	{
 		if (state == IN_NORMAL)
 			in_normal(&store, &state, *current);
-		else if (state == IN_QUOTE)
-			in_quote(&store, &state, *current);
+		else if (state == IN_DOUBLE_QUOTE)
+			in_double_quote(&store, &state, *current);
+		else if (state == IN_SINGLE_QUOTE)
+			in_single_quote(&store, &state, *current);
 		else if (state == IN_OPERATOR)
 			in_operator(&store, &state, *current);
 		else if (state == ON_SUCCESS)


### PR DESCRIPTION
# PR: tokenizeでダブルクォートとシングルクォートを区別

## やったこと
<!--
「このPRで何を実現したか」を一言で簡潔に列挙してください。
チームでの認識合わせのため、最初に目を通す人の「PRを読むモチベーション」になります。
- ~~~画面を追加しました
- ~~~API連携の処理をした。
-->
- tokenizeの状態として`IN_QUOTE`を削除し、`IN_DOUBLE_QUOTE`と`IN_SINGLE_QUOTE`に分割しました
- ダブルクォート(`"`)とシングルクォート(`'`)を個別に処理できるようになりました
- `in_quote.c`を`in_double_quote.c`と`in_single_quote.c`に分割しました
- `in_normal.c`の`by_quote`関数で、クォートの種類に応じて適切な状態に遷移するように修正しました

## 懸念点 / レビューしてほしいポイント
<!--
レビューの観点を明確にしておくと、レビュワーも的確なフィードバックができます。
「この書き方でよかったか不安」「stateの持ち方に自信がない」など、些細なことでもOKです。
-->
- クォートの種類を判別する処理が`in_normal.c`の`by_quote`関数内で適切か
- 今後、ダブルクォート内での変数展開処理などを追加する際に、この設計で問題ないか
- エスケープシーケンスの処理をどこで行うべきか（現状は未実装）

## 動作確認
<!--
自分の変更をレビュワーが動作チェックできるように書きましょう！

-->
- [ ] norminetteを通過している。
- [ ] makeコマンドでビルドできる。
- [ ] valgrindでリークチェックをした。(`valgrind --leak-check=full --suppressions=readline.supp --show-leak-kinds=all -s -q ./minishell`)
- [ ] シングルクォートで囲まれた文字列が正しくトークン化される（例: `echo 'hello world'`）
- [ ] ダブルクォートで囲まれた文字列が正しくトークン化される（例: `echo "hello world"`）
- [ ] クォートが閉じられていない場合にエラーになる（例: `echo "hello`）
- [ ] 空のクォートが正しく処理される（例: `echo ""` や `echo ''`）

## ひとこと
<!--
シンプルな感想を書きましょう！
-->
シェルでダブルクォートとシングルクォートの振る舞いが異なることに気づき、設計を見直しました。これで変数展開などの処理を追加しやすくなったはずです！
