### PR TITLE
fix: export の返り値を終了ステータスに修正

### DIFF
--- a/src/builtin/export.c
+++ b/src/builtin/export.c
@@ -6,7 +6,7 @@
 /*   By: surayama <surayama@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/11/29 20:29:03 by surayama          #+#    #+#             */
-/*   Updated: 2025/12/06 16:20:07 by surayama         ###   ########.fr       */
+/*   Updated: 2026/03/03 19:31:33 by surayama         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,21 +21,21 @@ static char	*get_value_from_assignment(const char *assignment);
 int	export(t_list *argv, t_shell_table *shell_table)
 {
 	if (!argv || !argv->content)
-		return (ERROR);
+		return (1);
 	skip_head_node(&argv);
 	if (!argv)
 	{
 		st_print_env(shell_table);
-		return (SUCCESS);
+		return (0);
 	}
 	while (argv)
 	{
 		if (insert_assignment(shell_table,
 				(const char *)argv->content) == ERROR)
-			return (ERROR);
+			return (1);
 		skip_head_node(&argv);
 	}
-	return (SUCCESS);
+	return (0);
 }
 
 static void	skip_head_node(t_list **argv)


### PR DESCRIPTION
## Summary
- `export` の返り値を `ERROR (-1)` / `SUCCESS (0)` から、シェルの終了ステータス `0` (成功) / `1` (失敗) に変更
- `-1` を返すと終了ステータスが `255` になる問題を修正

## 変更内容
- `export()` 関数の返り値のみ変更（内部関数 `insert_assignment` は `ERROR`/`SUCCESS` のまま）

Closes #60

## Test plan
- [x] `export FOO=bar; echo $?` → `0`
- [x] 不正な入力時に `echo $?` → `1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)