### PR TITLE
parser → parse にリネーム

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -35,7 +35,7 @@ make                 # コンテナ内でビルド
 シェルは以下のインタープリタパイプラインに従う:
 
 ```
-Input → tokenize() → heredoc() → variable_expand() → remove_quotes() → parser() → AST → execute
+Input → tokenize() → heredoc() → variable_expand() → remove_quotes() → parse() → AST → execute
 ```
 
 ### パイプラインの各段階
@@ -46,7 +46,7 @@ Input → tokenize() → heredoc() → variable_expand() → remove_quotes() →
 
 3. **クォート削除** (`src/component/remove_quotes/`) — 展開後のトークンからクォート文字を除去。
 
-4. **parser** (`src/parser/`) — 再帰下降パーサ。二分木ASTを生成。ノード型: `PIPE`(内部ノード)、`CMD`(葉ノード、`t_cmd` に argv リストとリダイレクションリストを持つ)。
+4. **parse** (`src/parse/`) — 再帰下降パーサ。二分木ASTを生成。ノード型: `PIPE`(内部ノード)、`CMD`(葉ノード、`t_cmd` に argv リストとリダイレクションリストを持つ)。
 
 5. **実行** — 未実装。エントリポイントは `src/callback/on_input.c`。
 
@@ -60,9 +60,9 @@ Input → tokenize() → heredoc() → variable_expand() → remove_quotes() →
 ### 主要データ構造 (`includes/`)
 
 - `t_shell_table` / `t_shell_node` — 環境変数ハッシュテーブル (`shell_table.h`)
-- `t_ast` — AST木。`t_ast_type` (PIPE/CMD) と left/right 子ノード (`parser.h`)
-- `t_cmd` — コマンド。`t_list *argv` と `t_list *redirs` を持つ (`parser.h`)
-- `t_redir` — リダイレクション。`t_redir_kind` (R_IN, R_OUT_TRUNC, R_OUT_APPEND) と filename (`parser.h`)
+- `t_ast` — AST木。`t_ast_type` (PIPE/CMD) と left/right 子ノード (`parse.h`)
+- `t_cmd` — コマンド。`t_list *argv` と `t_list *redirs` を持つ (`parse.h`)
+- `t_redir` — リダイレクション。`t_redir_kind` (R_IN, R_OUT_TRUNC, R_OUT_APPEND) と filename (`parse.h`)
 - `t_list` — libft のリンクリスト。トークンリストや引数リストとして全体で使用
 
 ## Critical Rules

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ SRCS_MAND	:=	src/main.c \
 				src/checker/tokenize_checker.c \
 				src/checker/heredoc_checker.c \
 				src/checker/shell_table_checker.c \
-				src/checker/parser_checker.c \
+				src/checker/parse_checker.c \
 				src/checker/path_checker.c \
 				src/checker/directory_checker.c \
 				src/checker/expand_checker.c \
@@ -91,16 +91,16 @@ SRCS_MAND	:=	src/main.c \
 				src/tokenize/store/free_store.c \
 				src/tokenize/store/push_token.c \
 				src/tokenize/store/add_buffer.c \
-				src/parser/parser.c \
-				src/parser/utils/add_to_cmd.c \
-				src/parser/utils/new_ast_node.c \
-				src/parser/utils/new_cmd.c \
-				src/parser/utils/new_redir.c \
-				src/parser/utils/token_check.c \
-				src/parser/utils/free_ast.c \
-				src/parser/utils/print_ast.c \
-				src/parser/utils/print_ast_utils.c \
-				src/parser/utils/print_ast_utils2.c \
+				src/parse/parse.c \
+				src/parse/utils/add_to_cmd.c \
+				src/parse/utils/new_ast_node.c \
+				src/parse/utils/new_cmd.c \
+				src/parse/utils/new_redir.c \
+				src/parse/utils/token_check.c \
+				src/parse/utils/free_ast.c \
+				src/parse/utils/print_ast.c \
+				src/parse/utils/print_ast_utils.c \
+				src/parse/utils/print_ast_utils2.c \
 				src/component/heredoc/heredoc.c \
 				src/component/heredoc/heredoc_prompt.c \
 				src/component/heredoc/tmpfile.c \

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -16,7 +16,7 @@
 # include "constants.h"
 # include "heredoc.h"
 # include "libft.h"
-# include "parser.h"
+# include "parse.h"
 # include "prompt.h"
 # include "path.h"
 # include "remove_quotes.h"
@@ -30,7 +30,7 @@ void	on_input(char *input, t_shell_table *shell_table);
 void	tokenize_checker(char *input, t_shell_table *shell_table);
 void	heredoc_checker(char *input, t_shell_table *shell_table);
 void	shell_table_checker(t_shell_table *shell_table);
-void	parser_checker(char *input, t_shell_table *shell_table);
+void	parse_checker(char *input, t_shell_table *shell_table);
 void	directory_checker(char *input, t_shell_table *shell_table);
 void	path_checker(char *input, t_shell_table *shell_table);
 void	builtin_checker(char *input, t_shell_table *shell_table);

--- a/includes/parse.h
+++ b/includes/parse.h
@@ -1,7 +1,7 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   parser.h                                           :+:      :+:    :+:   */
+/*   parse.h                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: kjikuhar <kjikuhar@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
@@ -10,8 +10,8 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#ifndef PARSER_H
-# define PARSER_H
+#ifndef PARSE_H
+# define PARSE_H
 
 # include "libft.h"
 # include "constants.h"
@@ -59,7 +59,7 @@ typedef struct s_ast
 }					t_ast;
 
 /* main function------------------------------------------------------------- */
-t_ast			*parser(t_list *token_head);
+t_ast			*parse(t_list *token_head);
 
 /* AST's token utils--------------------------------------------------------- */
 bool			is_word(const t_list *node);

--- a/src/checker/parse_checker.c
+++ b/src/checker/parse_checker.c
@@ -1,7 +1,7 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   parser_checker.c                                   :+:      :+:    :+:   */
+/*   parse_checker.c                                    :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: kjikuhar <kjikuhar@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
@@ -19,7 +19,7 @@ static void	on_exit_token(t_list *token_list)
 	exit(0);
 }
 
-void	parser_checker(char *input, t_shell_table *shell_table)
+void	parse_checker(char *input, t_shell_table *shell_table)
 {
 	t_list	*token_list;
 	t_ast	*ast_root;
@@ -33,7 +33,7 @@ void	parser_checker(char *input, t_shell_table *shell_table)
 	}
 	if (token_list->content && ft_strncmp(token_list->content, "exit", 5) == 0)
 		on_exit_token(token_list);
-	ast_root = parser(token_list);
+	ast_root = parse(token_list);
 	print_ast(ast_root);
 	free_ast(ast_root);
 	ft_lstclear(&token_list, free);

--- a/src/parse/parse.c
+++ b/src/parse/parse.c
@@ -1,7 +1,7 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   parser.c                                           :+:      :+:    :+:   */
+/*   parse.c                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: kjikuhar <kjikuhar@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
@@ -10,7 +10,7 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "parser.h"
+#include "parse.h"
 
 static t_redir_kind	find_redir_kind(t_list *current)
 {
@@ -91,7 +91,7 @@ static t_ast	*parse_pipeline(t_list **current)
 	return (left);
 }
 
-t_ast	*parser(t_list *token_head)
+t_ast	*parse(t_list *token_head)
 {
 	t_list	*current;
 	t_ast	*root;

--- a/src/parse/utils/add_to_cmd.c
+++ b/src/parse/utils/add_to_cmd.c
@@ -10,7 +10,7 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "parser.h"
+#include "parse.h"
 
 bool	add_redir_to_cmd(t_cmd *cmd, t_redir_kind kind, const char *file)
 {

--- a/src/parse/utils/free_ast.c
+++ b/src/parse/utils/free_ast.c
@@ -10,7 +10,7 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "parser.h"
+#include "parse.h"
 
 static void	free_redir(void *ptr)
 {

--- a/src/parse/utils/new_ast_node.c
+++ b/src/parse/utils/new_ast_node.c
@@ -1,25 +1,27 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   new_cmd.c                                          :+:      :+:    :+:   */
+/*   new_ast_node.c                                     :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: kjikuhar <kjikuhar@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2025/11/14 18:29:38 by kjikuhar          #+#    #+#             */
-/*   Updated: 2025/11/19 23:39:34 by kjikuhar         ###   ########.fr       */
+/*   Created: 2025/11/14 18:29:33 by kjikuhar          #+#    #+#             */
+/*   Updated: 2025/11/19 23:39:24 by kjikuhar         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "parser.h"
+#include "parse.h"
 
-t_cmd	*new_cmd(void)
+t_ast	*new_ast_node(t_ast_type type)
 {
-	t_cmd	*cmd;
+	t_ast	*node;
 
-	cmd = malloc(sizeof(t_cmd));
-	if (!cmd)
+	node = malloc(sizeof(t_ast));
+	if (!node)
 		return (NULL);
-	cmd->argv = NULL;
-	cmd->redirs = NULL;
-	return (cmd);
+	node->type = type;
+	node->cmd = NULL;
+	node->left = NULL;
+	node->right = NULL;
+	return (node);
 }

--- a/src/parse/utils/new_cmd.c
+++ b/src/parse/utils/new_cmd.c
@@ -1,27 +1,25 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   new_ast_node.c                                     :+:      :+:    :+:   */
+/*   new_cmd.c                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: kjikuhar <kjikuhar@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2025/11/14 18:29:33 by kjikuhar          #+#    #+#             */
-/*   Updated: 2025/11/19 23:39:24 by kjikuhar         ###   ########.fr       */
+/*   Created: 2025/11/14 18:29:38 by kjikuhar          #+#    #+#             */
+/*   Updated: 2025/11/19 23:39:34 by kjikuhar         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "parser.h"
+#include "parse.h"
 
-t_ast	*new_ast_node(t_ast_type type)
+t_cmd	*new_cmd(void)
 {
-	t_ast	*node;
+	t_cmd	*cmd;
 
-	node = malloc(sizeof(t_ast));
-	if (!node)
+	cmd = malloc(sizeof(t_cmd));
+	if (!cmd)
 		return (NULL);
-	node->type = type;
-	node->cmd = NULL;
-	node->left = NULL;
-	node->right = NULL;
-	return (node);
+	cmd->argv = NULL;
+	cmd->redirs = NULL;
+	return (cmd);
 }

--- a/src/parse/utils/new_redir.c
+++ b/src/parse/utils/new_redir.c
@@ -10,7 +10,7 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "parser.h"
+#include "parse.h"
 
 t_redir	*new_redir(t_redir_kind kind, const char *filename)
 {

--- a/src/parse/utils/print_ast.c
+++ b/src/parse/utils/print_ast.c
@@ -10,7 +10,7 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "parser.h"
+#include "parse.h"
 
 void	print_pipe_node(t_ast *node, const char *prefix, bool is_last)
 {

--- a/src/parse/utils/print_ast_utils.c
+++ b/src/parse/utils/print_ast_utils.c
@@ -10,7 +10,7 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "parser.h"
+#include "parse.h"
 
 void	print_branch_line(const char *prefix, bool is_last, const char *text)
 {

--- a/src/parse/utils/print_ast_utils2.c
+++ b/src/parse/utils/print_ast_utils2.c
@@ -10,7 +10,7 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "parser.h"
+#include "parse.h"
 
 void	print_redir_entry(t_redir *redir, int index)
 {

--- a/src/parse/utils/token_check.c
+++ b/src/parse/utils/token_check.c
@@ -10,7 +10,7 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "parser.h"
+#include "parse.h"
 
 bool	is_word(const t_list *node)
 {


### PR DESCRIPTION
## Summary
- `src/parser/` → `src/parse/`、`parser()` → `parse()`、`parser_checker()` → `parse_checker()` にリネーム
- 他のパイプライン関数 (`tokenize`, `expand`) と動詞形で命名統一
- ヘッダガード、include パス、Makefile、CLAUDE.md を更新

## Test plan
- [x] Docker 内で `make re` がビルド成功すること
- [x] `./minishell --dev` で parse_checker が正常動作すること
- [ ] `make norm` で norminette エラーがないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)