### PR TITLE
③ feat: サブシェル (cmd1 && cmd2) | cmd3 サポート

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,7 @@ SRCS_MAND	:=	src/main.c \
 				src/tokenize/store/add_buffer.c \
 				src/parse/parse.c \
 				src/parse/parse_list.c \
+				src/parse/parse_pipeline.c \
 				src/parse/utils/add_to_cmd.c \
 				src/parse/utils/new_ast_node.c \
 				src/parse/utils/new_cmd.c \

--- a/includes/parse.h
+++ b/includes/parse.h
@@ -29,7 +29,8 @@ typedef enum e_ast_type
 	PIPE,
 	CMD,
 	AND,
-	OR
+	OR,
+	SUBSHELL
 }					t_ast_type;
 
 typedef enum e_redir_kind
@@ -62,7 +63,9 @@ typedef struct s_ast
 
 /* main function------------------------------------------------------------- */
 t_ast			*parse(t_list *token_head);
+t_ast			*parse_cmd(t_list **current);
 t_ast			*parse_pipeline(t_list **current);
+t_ast			*parse_list(t_list **current);
 
 /* AST's token utils--------------------------------------------------------- */
 bool			is_word(const t_list *node);

--- a/src/execute/exec_ast.c
+++ b/src/execute/exec_ast.c
@@ -24,6 +24,22 @@ static int	exec_logical(t_ast *node, t_shell_table *shell_table)
 	return (status);
 }
 
+static int	exec_subshell(t_ast *node, t_shell_table *shell_table)
+{
+	pid_t	pid;
+	int		wstatus;
+
+	pid = fork();
+	if (pid < 0)
+		return (perror("fork"), 1);
+	if (pid == 0)
+		exit(exec_ast(node->right, shell_table));
+	waitpid(pid, &wstatus, 0);
+	if (ft_wifexited(wstatus))
+		return (ft_wexitstatus(wstatus));
+	return (1);
+}
+
 int	exec_ast(t_ast *node, t_shell_table *shell_table)
 {
 	if (!node)
@@ -34,5 +50,7 @@ int	exec_ast(t_ast *node, t_shell_table *shell_table)
 		return (exec_cmd(node, shell_table));
 	if (node->type == AND || node->type == OR)
 		return (exec_logical(node, shell_table));
+	if (node->type == SUBSHELL)
+		return (exec_subshell(node, shell_table));
 	return (EXIT_FAILURE);
 }

--- a/src/expand/expand_wildcard/resolve_wildcard.c
+++ b/src/expand/expand_wildcard/resolve_wildcard.c
@@ -94,4 +94,3 @@ static t_list	*build_full_paths(t_list *matches, const char *abs_dir)
 	ft_lstclear(&matches, free);
 	return (result);
 }
-

--- a/src/parse/parse.c
+++ b/src/parse/parse.c
@@ -39,7 +39,7 @@ static int	parse_redir(t_list **current, t_cmd *cmd)
 	return (SUCCESS);
 }
 
-static t_ast	*parse_cmd(t_list **current)
+t_ast	*parse_cmd(t_list **current)
 {
 	t_ast	*ast;
 	t_cmd	*cmd;
@@ -49,7 +49,8 @@ static t_ast	*parse_cmd(t_list **current)
 		return (NULL);
 	while (*current && !is_symbol(*current, "|")
 		&& !is_symbol(*current, "&&")
-		&& !is_symbol(*current, "||"))
+		&& !is_symbol(*current, "||")
+		&& !is_symbol(*current, ")"))
 	{
 		if (is_redir(*current))
 		{
@@ -70,25 +71,3 @@ static t_ast	*parse_cmd(t_list **current)
 	return (ast);
 }
 
-t_ast	*parse_pipeline(t_list **current)
-{
-	t_ast	*left;
-	t_ast	*pipe_node;
-
-	left = parse_cmd(current);
-	if (!left)
-		return (NULL);
-	if (*current && is_symbol(*current, "|"))
-	{
-		*current = (*current)->next;
-		pipe_node = new_ast_node(PIPE);
-		if (!pipe_node)
-			return (free_ast(left), NULL);
-		pipe_node->left = left;
-		pipe_node->right = parse_pipeline(current);
-		if (!pipe_node->right)
-			return (free_ast(pipe_node), NULL);
-		return (pipe_node);
-	}
-	return (left);
-}

--- a/src/parse/parse_list.c
+++ b/src/parse/parse_list.c
@@ -21,7 +21,7 @@ static t_ast_type	get_logical_type(t_list *current)
 	return (CMD);
 }
 
-static t_ast	*parse_list(t_list **current)
+t_ast	*parse_list(t_list **current)
 {
 	t_ast		*left;
 	t_ast		*node;

--- a/src/parse/parse_pipeline.c
+++ b/src/parse/parse_pipeline.c
@@ -1,0 +1,60 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   parse_pipeline.c                                   :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: surayama <surayama@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/04/16 00:00:00 by surayama          #+#    #+#             */
+/*   Updated: 2026/04/16 00:00:00 by surayama         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "parse.h"
+
+static t_ast	*parse_subshell(t_list **current)
+{
+	t_ast	*node;
+
+	*current = (*current)->next;
+	node = new_ast_node(SUBSHELL);
+	if (!node)
+		return (NULL);
+	node->right = parse_list(current);
+	if (!node->right)
+		return (free_ast(node), NULL);
+	if (!*current || !is_symbol(*current, ")"))
+		return (free_ast(node), NULL);
+	*current = (*current)->next;
+	return (node);
+}
+
+static t_ast	*parse_primary(t_list **current)
+{
+	if (*current && is_symbol(*current, "("))
+		return (parse_subshell(current));
+	return (parse_cmd(current));
+}
+
+t_ast	*parse_pipeline(t_list **current)
+{
+	t_ast	*left;
+	t_ast	*pipe_node;
+
+	left = parse_primary(current);
+	if (!left)
+		return (NULL);
+	if (*current && is_symbol(*current, "|"))
+	{
+		*current = (*current)->next;
+		pipe_node = new_ast_node(PIPE);
+		if (!pipe_node)
+			return (free_ast(left), NULL);
+		pipe_node->left = left;
+		pipe_node->right = parse_pipeline(current);
+		if (!pipe_node->right)
+			return (free_ast(pipe_node), NULL);
+		return (pipe_node);
+	}
+	return (left);
+}

--- a/src/parse/utils/free_ast.c
+++ b/src/parse/utils/free_ast.c
@@ -37,14 +37,12 @@ void	free_ast(t_ast *ast)
 {
 	if (!ast)
 		return ;
-	if (ast->type == PIPE)
+	if (ast->type == CMD)
+		free_cmd(ast->cmd);
+	else
 	{
 		free_ast(ast->left);
 		free_ast(ast->right);
-	}
-	else if (ast->type == CMD)
-	{
-		free_cmd(ast->cmd);
 	}
 	free(ast);
 }

--- a/src/parse/utils/token_check.c
+++ b/src/parse/utils/token_check.c
@@ -25,6 +25,8 @@ bool	is_word(const t_list *node)
 		ft_strncmp(s, "|", 2) == 0 || \
 		ft_strncmp(s, "&&", 3) == 0 || \
 		ft_strncmp(s, "||", 3) == 0 || \
+		ft_strncmp(s, "(", 2) == 0 || \
+		ft_strncmp(s, ")", 2) == 0 || \
 		ft_strncmp(s, "EOF", 4) == 0)
 		return (false);
 	return (true);


### PR DESCRIPTION
## Summary
- AST に `SUBSHELL` ノード型を追加 (`includes/parse.h`)
- `parse_pipeline.c` を新規作成: `parse_subshell` / `parse_primary` / `parse_pipeline` を分離
- `exec_subshell`: `fork()` して子プロセスで AST サブツリーを実行 (`src/execute/exec_ast.c`)
- `free_ast` を修正: CMD 以外は全て left/right を再帰 free（AND/OR/SUBSHELL のリーク修正）
- `is_word` から `(` `)` を除外、`parse_cmd` に `)` 停止条件追加

### 文法の優先順位
```
parse → parse_list(&&/||) → parse_pipeline(|) → parse_primary → parse_subshell / parse_cmd
```

**依存**: #70 (&&/|| + expand 移動) がベース

## Test plan
- [x] `(echo hello)` → `hello`
- [x] `(echo a && echo b)` → `a\nb`
- [x] `(false || echo fallback)` → `fallback`
- [x] `(cd /tmp && pwd) && pwd` → `/tmp` + 元のディレクトリ（サブシェル内の cd は親に影響しない）
- [x] `(echo a && echo b) | cat` → `a\nb`（サブシェル + パイプ）
- [x] `(export FOO=sub) && echo $FOO` → 空（サブシェル内の export は親に影響しない）
- [x] `echo hello | (cat)` → `hello`（パイプ + サブシェル）

🤖 Generated with [Claude Code](https://claude.com/claude-code)