### PR TITLE
① feat: コマンド実行中のシグナルハンドリング

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,7 @@ SRCS_MAND	:=	src/main.c \
 				src/execute/utils/ft_wexitstatus.c \
 				src/execute/utils/ft_wifexited.c \
 				src/execute/command/find_exec_path.c \
+				src/execute/command/exec_external_cmd.c \
 				src/execute/command/exec_builtin_cmd.c \
 				src/execute/command/list_to_argv.c \
 				src/execute/pipe/exec_pipe_child.c \

--- a/includes/execute.h
+++ b/includes/execute.h
@@ -24,6 +24,8 @@ int					exec_builtin_cmd(t_ast *node, t_shell_table *shell_table);
 int					exec_cmd(t_ast *node, t_shell_table *shell_table);
 char				*find_exec_path(const char *cmd, \
 							t_shell_table *shell_table);
+int					exec_external_cmd(char **argv, \
+							t_shell_table *shell_table);
 int					exec_pipe(t_ast *node, t_shell_table *shell_table);
 void				exec_left_child(t_ast *node, \
 						t_shell_table *shell_table, int fd[2]);

--- a/src/callback/on_input.c
+++ b/src/callback/on_input.c
@@ -6,36 +6,17 @@
 /*   By: kjikuhar <kjikuhar@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/10/10 17:04:25 by surayama          #+#    #+#             */
-/*   Updated: 2026/04/17 21:23:54 by kjikuhar         ###   ########.fr       */
+/*   Updated: 2026/04/17 21:43:48 by kjikuhar         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-<<<<<<< HEAD
 int	on_input(char *input, t_shell_table *shell_table, int last_status)
 {
 	t_list	*tokens;
 	t_ast	*ast;
 	int		current_status;
-=======
-static void	update_exit_status(t_shell_table *shell_table, int status)
-{
-	char	*status_str;
-
-	status_str = ft_itoa(status);
-	if (!status_str)
-		return ;
-	st_insert(shell_table, "?", status_str, false);
-	free(status_str);
-}
-
-void	on_input(char *input, t_shell_table *shell_table)
-{
-	t_list	*tokens;
-	t_ast	*ast;
-	int		status;
->>>>>>> 5796375 (wip: exec_ast の戻り値を $? として shell_table に保存)
 
 	tokens = tokenize(input);
 	if (!tokens)
@@ -51,15 +32,8 @@ void	on_input(char *input, t_shell_table *shell_table)
 	ast = parse(tokens);
 	ft_lstclear(&tokens, free);
 	if (!ast)
-<<<<<<< HEAD
 		return (2);
 	current_status = exec_ast(ast, shell_table);
 	free_ast(ast);
 	return (current_status);
-=======
-		return ;
-	status = exec_ast(ast, shell_table);
-	free_ast(ast);
-	update_exit_status(shell_table, status);
->>>>>>> 5796375 (wip: exec_ast の戻り値を $? として shell_table に保存)
 }

--- a/src/callback/on_input.c
+++ b/src/callback/on_input.c
@@ -12,11 +12,30 @@
 
 #include "minishell.h"
 
+<<<<<<< HEAD
 int	on_input(char *input, t_shell_table *shell_table, int last_status)
 {
 	t_list	*tokens;
 	t_ast	*ast;
 	int		current_status;
+=======
+static void	update_exit_status(t_shell_table *shell_table, int status)
+{
+	char	*status_str;
+
+	status_str = ft_itoa(status);
+	if (!status_str)
+		return ;
+	st_insert(shell_table, "?", status_str, false);
+	free(status_str);
+}
+
+void	on_input(char *input, t_shell_table *shell_table)
+{
+	t_list	*tokens;
+	t_ast	*ast;
+	int		status;
+>>>>>>> 5796375 (wip: exec_ast の戻り値を $? として shell_table に保存)
 
 	tokens = tokenize(input);
 	if (!tokens)
@@ -32,8 +51,15 @@ int	on_input(char *input, t_shell_table *shell_table, int last_status)
 	ast = parse(tokens);
 	ft_lstclear(&tokens, free);
 	if (!ast)
+<<<<<<< HEAD
 		return (2);
 	current_status = exec_ast(ast, shell_table);
 	free_ast(ast);
 	return (current_status);
+=======
+		return ;
+	status = exec_ast(ast, shell_table);
+	free_ast(ast);
+	update_exit_status(shell_table, status);
+>>>>>>> 5796375 (wip: exec_ast の戻り値を $? として shell_table に保存)
 }

--- a/src/execute/command/exec_external_cmd.c
+++ b/src/execute/command/exec_external_cmd.c
@@ -1,0 +1,60 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   exec_external_cmd.c                                :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: surayama <surayama@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/04/16 00:00:00 by surayama          #+#    #+#             */
+/*   Updated: 2026/04/16 00:00:00 by surayama         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "execute.h"
+
+static int	cmd_not_found(char **argv)
+{
+	if (ft_strchr(argv[0], '/'))
+	{
+		if (access(argv[0], F_OK) == 0)
+		{
+			ft_putstr_fd("jikussh: ", STDERR_FILENO);
+			perror(argv[0]);
+			ft_free_array((void **)argv);
+			return (126);
+		}
+		ft_putstr_fd("jikussh: ", STDERR_FILENO);
+		perror(argv[0]);
+		ft_free_array((void **)argv);
+		return (127);
+	}
+	ft_putstr_fd("jikussh: ", STDERR_FILENO);
+	ft_putstr_fd(argv[0], STDERR_FILENO);
+	ft_putstr_fd(": command not found\n", STDERR_FILENO);
+	ft_free_array((void **)argv);
+	return (127);
+}
+
+int	exec_external_cmd(char **argv, t_shell_table *shell_table)
+{
+	char		*cmd_path;
+	char		**new_envp;
+
+	cmd_path = find_exec_path(argv[0], shell_table);
+	if (!cmd_path)
+		return (cmd_not_found(argv));
+	new_envp = export_envp(shell_table);
+	if (!new_envp)
+	{
+		free(cmd_path);
+		ft_free_array((void **)argv);
+		return (1);
+	}
+	execve(cmd_path, argv, new_envp);
+	perror(cmd_path);
+	free(cmd_path);
+	st_destroy(shell_table);
+	ft_free_array((void **)new_envp);
+	ft_free_array((void **)argv);
+	return (127);
+}

--- a/src/execute/exec_cmd.c
+++ b/src/execute/exec_cmd.c
@@ -6,7 +6,7 @@
 /*   By: kjikuhar <kjikuhar@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/11/14 17:18:25 by kjikuhar          #+#    #+#             */
-/*   Updated: 2026/04/16 00:00:00 by surayama         ###   ########.fr       */
+/*   Updated: 2026/04/17 21:41:55 by kjikuhar         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -88,17 +88,43 @@ static int	fork_and_exec(t_ast *node, t_shell_table *shell_table)
 	return (128 + WTERMSIG(wstatus));
 }
 
+static void	restore_fds(int saved_in, int saved_out)
+{
+	dup2(saved_in, STDIN_FILENO);
+	dup2(saved_out, STDOUT_FILENO);
+	close(saved_in);
+	close(saved_out);
+}
+
+static int	exec_builtin_with_redir(t_ast *node, t_shell_table *st)
+{
+	int	saved_in;
+	int	saved_out;
+	int	status;
+
+	saved_in = dup(STDIN_FILENO);
+	saved_out = dup(STDOUT_FILENO);
+	if (node->cmd->redirs
+		&& exec_redirs(node->cmd->redirs) != 0)
+	{
+		restore_fds(saved_in, saved_out);
+		return (1);
+	}
+	status = exec_builtin_cmd(node, st);
+	restore_fds(saved_in, saved_out);
+	return (status);
+}
+
 int	exec_cmd(t_ast *node, t_shell_table *shell_table)
 {
 	int		status;
 
-	if (node->cmd->redirs)
-	{
-		if (exec_redirs(node->cmd->redirs) != 0)
-			return (1);
-	}
 	status = exec_builtin_cmd(node, shell_table);
 	if (status != -1)
+	{
+		if (node->cmd->redirs)
+			return (exec_builtin_with_redir(node, shell_table));
 		return (status);
+	}
 	return (fork_and_exec(node, shell_table));
 }

--- a/src/execute/exec_cmd.c
+++ b/src/execute/exec_cmd.c
@@ -13,53 +13,6 @@
 #include "execute.h"
 #include "signal_handler.h"
 
-static int	cmd_not_found(char **argv)
-{
-	if (ft_strchr(argv[0], '/'))
-	{
-		if (access(argv[0], F_OK) == 0)
-		{
-			ft_putstr_fd("jikussh: ", STDERR_FILENO);
-			perror(argv[0]);
-			ft_free_array((void **)argv);
-			return (126);
-		}
-		ft_putstr_fd("jikussh: ", STDERR_FILENO);
-		perror(argv[0]);
-		ft_free_array((void **)argv);
-		return (127);
-	}
-	ft_putstr_fd("jikussh: ", STDERR_FILENO);
-	ft_putstr_fd(argv[0], STDERR_FILENO);
-	ft_putstr_fd(": command not found\n", STDERR_FILENO);
-	ft_free_array((void **)argv);
-	return (127);
-}
-
-static int	exec_external_cmd(char **argv, t_shell_table *shell_table)
-{
-	char		*cmd_path;
-	char		**new_envp;
-
-	cmd_path = find_exec_path(argv[0], shell_table);
-	if (!cmd_path)
-		return (cmd_not_found(argv));
-	new_envp = export_envp(shell_table);
-	if (!new_envp)
-	{
-		free(cmd_path);
-		ft_free_array((void **)argv);
-		return (1);
-	}
-	execve(cmd_path, argv, new_envp);
-	perror(cmd_path);
-	free(cmd_path);
-	st_destroy(shell_table);
-	ft_free_array((void **)new_envp);
-	ft_free_array((void **)argv);
-	return (127);
-}
-
 static int	fork_and_exec(t_ast *node, t_shell_table *shell_table)
 {
 	pid_t	pid;

--- a/src/execute/exec_cmd.c
+++ b/src/execute/exec_cmd.c
@@ -11,6 +11,7 @@
 /* ************************************************************************** */
 
 #include "execute.h"
+#include "signal_handler.h"
 
 static int	cmd_not_found(char **argv)
 {
@@ -70,6 +71,7 @@ static int	fork_and_exec(t_ast *node, t_shell_table *shell_table)
 		return (perror("fork"), 1);
 	if (pid == 0)
 	{
+		set_signal_default();
 		if (node->cmd->redirs)
 			if (exec_redirs(node->cmd->redirs) != 0)
 				exit(1);
@@ -78,10 +80,12 @@ static int	fork_and_exec(t_ast *node, t_shell_table *shell_table)
 			exit(127);
 		exit(exec_external_cmd(argv, shell_table));
 	}
+	set_signal_ignore();
 	waitpid(pid, &wstatus, 0);
+	set_signal_interactive();
 	if (ft_wifexited(wstatus))
 		return (ft_wexitstatus(wstatus));
-	return (1);
+	return (128 + WTERMSIG(wstatus));
 }
 
 int	exec_cmd(t_ast *node, t_shell_table *shell_table)

--- a/src/execute/exec_pipe.c
+++ b/src/execute/exec_pipe.c
@@ -11,6 +11,7 @@
 /* ************************************************************************** */
 
 #include "execute.h"
+#include "signal_handler.h"
 
 static int	exec_pipe_left(t_ast *node, t_shell_table *shell_table, \
 				pid_t *left, int fd[2])
@@ -62,9 +63,11 @@ int	exec_pipe(t_ast *node, t_shell_table *shell_table)
 	}
 	close(fd[0]);
 	close(fd[1]);
+	set_signal_ignore();
 	waitpid(left, &exit_status_left_child, 0);
 	waitpid(right, &exit_status_right_child, 0);
+	set_signal_interactive();
 	if (ft_wifexited(exit_status_right_child))
 		return (ft_wexitstatus(exit_status_right_child));
-	return (1);
+	return (128 + WTERMSIG(exit_status_right_child));
 }

--- a/src/execute/pipe/exec_pipe_child.c
+++ b/src/execute/pipe/exec_pipe_child.c
@@ -11,6 +11,7 @@
 /* ************************************************************************** */
 
 #include "execute.h"
+#include "signal_handler.h"
 
 void	exec_left_child(t_ast *node, t_shell_table *shell_table, int fd[2])
 {
@@ -26,6 +27,7 @@ void	exec_left_child(t_ast *node, t_shell_table *shell_table, int fd[2])
 	}
 	close(fd[0]);
 	close(fd[1]);
+	set_signal_default();
 	left_node = node->left;
 	right_node = node->right;
 	free(node);
@@ -49,6 +51,7 @@ void	exec_right_child(t_ast *node, t_shell_table *shell_table, int fd[2])
 	}
 	close(fd[1]);
 	close(fd[0]);
+	set_signal_default();
 	left_node = node->left;
 	right_node = node->right;
 	free(node);


### PR DESCRIPTION
## Summary
- 子プロセス（外部コマンド・パイプ）で `set_signal_default()` を呼び、SIGINT/SIGQUIT をデフォルト動作に復帰
- 親プロセスで子プロセス待機中は `set_signal_ignore()` で SIGINT を無視（親が終了しないように）
- `waitpid` 後に `set_signal_interactive()` でプロンプト用ハンドラに復帰
- シグナルによる終了時の exit status を `128 + signal番号` に設定（Ctrl+C → 130）

### 変更ファイル
- `src/execute/exec_cmd.c` — `fork_and_exec` にシグナル切り替え追加
- `src/execute/exec_pipe.c` — `exec_pipe` にシグナル切り替え追加
- `src/execute/pipe/exec_pipe_child.c` — 子プロセスで `set_signal_default` 呼び出し

## Test plan
- [ ] `sleep 10` 中に Ctrl+C → コマンド中断、プロンプトに戻る
- [ ] `sleep 10` 中に Ctrl+\\ → `Quit: 3` 表示、コマンド中断
- [ ] Ctrl+C 後に `echo $?` → `130`
- [ ] Ctrl+\\ 後に `echo $?` → `131`
- [ ] プロンプトで Ctrl+C → 新しいプロンプト行（既存動作維持）
- [ ] プロンプトで Ctrl+\\ → 無視（既存動作維持）
- [ ] `cat | cat | cat` で Ctrl+C → 全プロセス終了、プロンプトに戻る
- [ ] `echo hello` → 正常終了（シグナル変更が通常動作に影響しない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)