### PR TITLE
fix: リダイレクト実行の修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,7 @@ SRCS_MAND	:=	src/main.c \
 				src/execute/utils/ft_wexitstatus.c \
 				src/execute/utils/ft_wifexited.c \
 				src/execute/command/find_exec_path.c \
+				src/execute/command/exec_external_cmd.c \
 				src/execute/command/exec_builtin_cmd.c \
 				src/execute/command/list_to_argv.c \
 				src/execute/pipe/exec_pipe_child.c \

--- a/includes/execute.h
+++ b/includes/execute.h
@@ -24,6 +24,8 @@ int					exec_builtin_cmd(t_ast *node, t_shell_table *shell_table);
 int					exec_cmd(t_ast *node, t_shell_table *shell_table);
 char				*find_exec_path(const char *cmd, \
 							t_shell_table *shell_table);
+int					exec_external_cmd(char **argv, \
+							t_shell_table *shell_table);
 int					exec_pipe(t_ast *node, t_shell_table *shell_table);
 void				exec_left_child(t_ast *node, \
 						t_shell_table *shell_table, int fd[2]);

--- a/src/execute/command/exec_external_cmd.c
+++ b/src/execute/command/exec_external_cmd.c
@@ -1,0 +1,60 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   exec_external_cmd.c                                :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: surayama <surayama@student.42tokyo.jp>     +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/04/16 00:00:00 by surayama          #+#    #+#             */
+/*   Updated: 2026/04/16 00:00:00 by surayama         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "execute.h"
+
+static int	cmd_not_found(char **argv)
+{
+	if (ft_strchr(argv[0], '/'))
+	{
+		if (access(argv[0], F_OK) == 0)
+		{
+			ft_putstr_fd("jikussh: ", STDERR_FILENO);
+			perror(argv[0]);
+			ft_free_array((void **)argv);
+			return (126);
+		}
+		ft_putstr_fd("jikussh: ", STDERR_FILENO);
+		perror(argv[0]);
+		ft_free_array((void **)argv);
+		return (127);
+	}
+	ft_putstr_fd("jikussh: ", STDERR_FILENO);
+	ft_putstr_fd(argv[0], STDERR_FILENO);
+	ft_putstr_fd(": command not found\n", STDERR_FILENO);
+	ft_free_array((void **)argv);
+	return (127);
+}
+
+int	exec_external_cmd(char **argv, t_shell_table *shell_table)
+{
+	char		*cmd_path;
+	char		**new_envp;
+
+	cmd_path = find_exec_path(argv[0], shell_table);
+	if (!cmd_path)
+		return (cmd_not_found(argv));
+	new_envp = export_envp(shell_table);
+	if (!new_envp)
+	{
+		free(cmd_path);
+		ft_free_array((void **)argv);
+		return (1);
+	}
+	execve(cmd_path, argv, new_envp);
+	perror(cmd_path);
+	free(cmd_path);
+	st_destroy(shell_table);
+	ft_free_array((void **)new_envp);
+	ft_free_array((void **)argv);
+	return (127);
+}

--- a/src/execute/exec_cmd.c
+++ b/src/execute/exec_cmd.c
@@ -11,53 +11,7 @@
 /* ************************************************************************** */
 
 #include "execute.h"
-
-static int	cmd_not_found(char **argv)
-{
-	if (ft_strchr(argv[0], '/'))
-	{
-		if (access(argv[0], F_OK) == 0)
-		{
-			ft_putstr_fd("jikussh: ", STDERR_FILENO);
-			perror(argv[0]);
-			ft_free_array((void **)argv);
-			return (126);
-		}
-		ft_putstr_fd("jikussh: ", STDERR_FILENO);
-		perror(argv[0]);
-		ft_free_array((void **)argv);
-		return (127);
-	}
-	ft_putstr_fd("jikussh: ", STDERR_FILENO);
-	ft_putstr_fd(argv[0], STDERR_FILENO);
-	ft_putstr_fd(": command not found\n", STDERR_FILENO);
-	ft_free_array((void **)argv);
-	return (127);
-}
-
-static int	exec_external_cmd(char **argv, t_shell_table *shell_table)
-{
-	char		*cmd_path;
-	char		**new_envp;
-
-	cmd_path = find_exec_path(argv[0], shell_table);
-	if (!cmd_path)
-		return (cmd_not_found(argv));
-	new_envp = export_envp(shell_table);
-	if (!new_envp)
-	{
-		free(cmd_path);
-		ft_free_array((void **)argv);
-		return (1);
-	}
-	execve(cmd_path, argv, new_envp);
-	perror(cmd_path);
-	free(cmd_path);
-	st_destroy(shell_table);
-	ft_free_array((void **)new_envp);
-	ft_free_array((void **)argv);
-	return (127);
-}
+#include "signal_handler.h"
 
 static int	fork_and_exec(t_ast *node, t_shell_table *shell_table)
 {
@@ -84,17 +38,43 @@ static int	fork_and_exec(t_ast *node, t_shell_table *shell_table)
 	return (1);
 }
 
+static void	restore_fds(int saved_in, int saved_out)
+{
+	dup2(saved_in, STDIN_FILENO);
+	dup2(saved_out, STDOUT_FILENO);
+	close(saved_in);
+	close(saved_out);
+}
+
+static int	exec_builtin_with_redir(t_ast *node, t_shell_table *st)
+{
+	int	saved_in;
+	int	saved_out;
+	int	status;
+
+	saved_in = dup(STDIN_FILENO);
+	saved_out = dup(STDOUT_FILENO);
+	if (node->cmd->redirs
+		&& exec_redirs(node->cmd->redirs) != 0)
+	{
+		restore_fds(saved_in, saved_out);
+		return (1);
+	}
+	status = exec_builtin_cmd(node, st);
+	restore_fds(saved_in, saved_out);
+	return (status);
+}
+
 int	exec_cmd(t_ast *node, t_shell_table *shell_table)
 {
 	int		status;
 
-	if (node->cmd->redirs)
-	{
-		if (exec_redirs(node->cmd->redirs) != 0)
-			return (1);
-	}
 	status = exec_builtin_cmd(node, shell_table);
 	if (status != -1)
+	{
+		if (node->cmd->redirs)
+			return (exec_builtin_with_redir(node, shell_table));
 		return (status);
+	}
 	return (fork_and_exec(node, shell_table));
 }

--- a/src/execute/exec_cmd.c
+++ b/src/execute/exec_cmd.c
@@ -65,16 +65,30 @@ static int	exec_builtin_with_redir(t_ast *node, t_shell_table *st)
 	return (status);
 }
 
+static bool	is_builtin(t_ast *node)
+{
+	static const char	*builtins[] = {"echo", "pwd", "cd",
+		"export", "unset", "exit", NULL};
+	int					i;
+	char				*name;
+
+	if (!node->cmd->argv || !node->cmd->argv->content)
+		return (false);
+	name = (char *)node->cmd->argv->content;
+	i = 0;
+	while (builtins[i])
+	{
+		if (ft_strncmp(name, builtins[i],
+				ft_strlen(builtins[i]) + 1) == 0)
+			return (true);
+		i++;
+	}
+	return (false);
+}
+
 int	exec_cmd(t_ast *node, t_shell_table *shell_table)
 {
-	int		status;
-
-	status = exec_builtin_cmd(node, shell_table);
-	if (status != -1)
-	{
-		if (node->cmd->redirs)
-			return (exec_builtin_with_redir(node, shell_table));
-		return (status);
-	}
+	if (is_builtin(node))
+		return (exec_builtin_with_redir(node, shell_table));
 	return (fork_and_exec(node, shell_table));
 }

--- a/src/execute/exec_cmd.c
+++ b/src/execute/exec_cmd.c
@@ -61,6 +61,7 @@ static int	exec_builtin_with_redir(t_ast *node, t_shell_table *st)
 		return (1);
 	}
 	status = exec_builtin_cmd(node, st);
+	fflush(stdout);
 	restore_fds(saved_in, saved_out);
 	return (status);
 }

--- a/src/parse/parse.c
+++ b/src/parse/parse.c
@@ -51,7 +51,7 @@ static t_ast	*parse_cmd(t_list **current)
 	{
 		if (is_redir(*current))
 		{
-			if (!parse_redir(current, cmd))
+			if (parse_redir(current, cmd) == ERROR)
 				return (free_cmd(cmd), NULL);
 		}
 		else if (is_word(*current))


### PR DESCRIPTION
## Summary
- リダイレクトが親プロセスの fd を壊す問題を修正（ビルトイン実行時に fd を save/restore）
- ビルトイン判定を実行前に行い、リダイレクト付きビルトインの二重実行を防止
- `parse_redir` の戻り値判定バグを修正（`!result` → `== ERROR`）
- ビルトイン実行後に `fflush(stdout)` を追加し、リダイレクト先にバッファが確実にフラッシュされるよう修正

## 問題の詳細

### 1. リダイレクトのパースが常に失敗する
`parse.c` の `parse_cmd()` で `!parse_redir(current, cmd)` としてリダイレクト成功を判定していた。`parse_redir` は成功時に `SUCCESS (0)` を返すが、`!0` は `true` のため、**リダイレクトが正しくパースされても常にエラーパスに入り、リダイレクト付きコマンドが全て無視されていた。**

### 2. ビルトインの二重実行
`exec_cmd()` で `exec_builtin_cmd()` を呼んでビルトインかどうかを判定していたが、この関数は判定と同時にコマンドを実行する。リダイレクトがある場合は `exec_builtin_with_redir()` 内で再度 `exec_builtin_cmd()` を呼ぶため、**ビルトインが2回実行されていた。** `is_builtin()` を新設し、実行前に判定と実行を分離した。

### 3. printf のバッファがリダイレクト先にフラッシュされない
`echo` 等のビルトインは `printf` で出力するが、`printf` は内部バッファリングを行う。`exec_builtin_with_redir()` でリダイレクト適用後にビルトインを実行し、fd を `restore_fds()` で元に戻すが、**その時点でバッファがまだフラッシュされていないため、データが元の stdout に流れてリダイレクト先ファイルに書き込まれなかった。** `fflush(stdout)` を fd 復元前に追加して解決。

### 4. リダイレクトが親プロセスの fd を壊す
ビルトインはforkせず親プロセスで実行されるため、リダイレクト時に `dup2` で stdin/stdout を上書きすると、コマンド終了後もシェル本体の fd が壊れたままだった。`dup()` で事前に保存し、実行後に `restore_fds()` で復元するようにした。

## Test plan
- [ ] `echo hello > /tmp/test_out && cat /tmp/test_out` で `hello` が表示される
- [ ] `echo hello >> /tmp/test_out` で追記される
- [ ] `cat < /tmp/test_out` で入力リダイレクトが動作する
- [ ] `export FOO=bar` 等ビルトインが1回だけ実行される
- [ ] パイプ内ビルトイン `echo hello | cat` が正常動作する
- [ ] `make test` (norminette + valgrind) が通る

🤖 Generated with [Claude Code](https://claude.com/claude-code)