### PR TITLE
Patch3: norminette対応 - enable_echoctlの移動

### DIFF
--- a/includes/signal_handler.h
+++ b/includes/signal_handler.h
@@ -19,6 +19,7 @@
 extern volatile sig_atomic_t	g_signal;
 
 void	setup_signal_handlers(void);
+void	enable_echoctl(void);
 void	set_signal_ignore(void);
 void	set_signal_default(void);
 void	set_signal_interactive(void);

--- a/src/signal/set_signals.c
+++ b/src/signal/set_signals.c
@@ -12,17 +12,7 @@
 
 #include "signal_handler.h"
 #include <readline/readline.h>
-#include <termios.h>
 #include <unistd.h>
-
-static void	enable_echoctl(void)
-{
-	struct termios	term;
-
-	tcgetattr(STDIN_FILENO, &term);
-	term.c_lflag |= ECHOCTL;
-	tcsetattr(STDIN_FILENO, TCSANOW, &term);
-}
 
 void	set_signal_ignore(void)
 {

--- a/src/signal/setup_signal_handlers.c
+++ b/src/signal/setup_signal_handlers.c
@@ -37,6 +37,16 @@ static void	disable_echoctl(void)
 	tcsetattr(STDIN_FILENO, TCSANOW, &term);
 }
 
+void	enable_echoctl(void)
+{
+	struct termios	term;
+
+	ft_memset(&term, 0, sizeof(term));
+	tcgetattr(STDIN_FILENO, &term);
+	term.c_lflag |= ECHOCTL;
+	tcsetattr(STDIN_FILENO, TCSANOW, &term);
+}
+
 void	setup_signal_handlers(void)
 {
 	struct sigaction	sa;


### PR DESCRIPTION
## Summary
- `enable_echoctl`を`set_signals.c`から`setup_signal_handlers.c`に移動し、norminetteの関数数制限（5関数/ファイル）に対応

## Test plan
- [ ] norminette が通ること
- [ ] `cat` / `sleep` 等のブロッキングコマンドで Ctrl+C → `^C` と改行が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)