### PR TITLE
Patch4: 未消費トークンによる構文エラー検出漏れを修正

### DIFF
--- a/src/parse/parse_list.c
+++ b/src/parse/parse_list.c
@@ -51,7 +51,14 @@ t_ast	*parse_list(t_list **current)
 t_ast	*parse(t_list *token_head)
 {
 	t_list	*current;
+	t_ast	*ast;
 
 	current = token_head;
-	return (parse_list(&current));
+	ast = parse_list(&current);
+	if (current != NULL)
+	{
+		free_ast(ast);
+		return (NULL);
+	}
+	return (ast);
 }

--- a/src/parse/parse_list.c
+++ b/src/parse/parse_list.c
@@ -57,6 +57,10 @@ t_ast	*parse(t_list *token_head)
 	ast = parse_list(&current);
 	if (current != NULL)
 	{
+		ft_putstr_fd("jikussh: syntax error near unexpected token `",
+			STDERR_FILENO);
+		ft_putstr_fd((char *)current->content, STDERR_FILENO);
+		ft_putendl_fd("'", STDERR_FILENO);
 		free_ast(ast);
 		return (NULL);
 	}


### PR DESCRIPTION
## Summary
- `parse()`完了後に未消費のトークンが残っている場合、構文エラー（exit status 2）を返すよう修正
- `cd ))))))))))))))))))))))))` 等の入力で `)` がパースされずに無視され、exit status 0 が返る問題を修正

## Test plan
- [ ] `cd ))))))))))))))))))))))))` → 構文エラー、`$?` が 2
- [ ] `echo hello)` → 構文エラー、`$?` が 2
- [ ] `echo hello` → 正常動作
- [ ] `(echo hello)` → サブシェルとして正常動作
- [ ] `echo a && echo b` → 正常動作
- [ ] `echo a | cat` → 正常動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)