### PR TITLE
fix: heredoc中のCtrl+Cで終了しない問題を修正

### DIFF
--- a/src/signal/set_signals.c
+++ b/src/signal/set_signals.c
@@ -11,7 +11,6 @@
 /* ************************************************************************** */
 
 #include "signal_handler.h"
-#include <readline/readline.h>
 #include <unistd.h>
 
 void	set_signal_ignore(void)
@@ -41,20 +40,13 @@ void	set_signal_interactive(void)
 	setup_signal_handlers();
 }
 
-static void	sigint_heredoc_handler(int sig)
-{
-	g_signal = sig;
-	write(STDOUT_FILENO, "\n", 1);
-	rl_done = 1;
-}
-
 void	set_signal_heredoc(void)
 {
 	struct sigaction	sa;
 
 	sigemptyset(&sa.sa_mask);
 	sa.sa_flags = 0;
-	sa.sa_handler = sigint_heredoc_handler;
+	sa.sa_handler = SIG_DFL;
 	sigaction(SIGINT, &sa, NULL);
 	sa.sa_handler = SIG_IGN;
 	sigaction(SIGQUIT, &sa, NULL);


### PR DESCRIPTION
## Summary
- `set_signal_heredoc()`のSIGINTハンドラを`rl_done`ベースのカスタムハンドラから`SIG_DFL`に変更
- heredoc子プロセスがCtrl+Cで即座に終了するようになる
- 不要になった`sigint_heredoc_handler`関数と`readline.h`インクルードを削除

## Test plan
- [ ] `cat << EOF` → Ctrl+C → heredocが中断されプロンプトに戻ること
- [ ] `cat << EOF` → 入力後に delimiter で正常終了すること
- [ ] heredoc中に Ctrl+\ → 何も起きないこと（SIGQUITは無視）

🤖 Generated with [Claude Code](https://claude.com/claude-code)